### PR TITLE
honours user-specified install prefix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -233,6 +233,11 @@ if(HAVE___SINCOS)
     add_definitions(-DHAVE___SINCOS)
 endif()
 
+# install fftw if we built our own version
+if(FORCE_OWN_FFTW)
+    install(DIRECTORY external/fftw/lib/ DESTINATION lib FILES_MATCHING PATTERN "*")
+endif()
+
 # ----------------------------------------------------------------------COPY SCRIPTS--
 
 list(APPEND RELION_SCRIPT_FILES star_printtable 

--- a/cmake/BuildFFTW.cmake
+++ b/cmake/BuildFFTW.cmake
@@ -57,7 +57,7 @@ if(NOT FFTW_FOUND)
     set(FFTW_FFTW3_LIB_DIR ${FFTW_EXTERNAL_LIBS_EXTRACT_TARGET}/fftw3)
     set(FFTW_FFTW3_BUILD_DIR ${FFTW_EXTERNAL_LIBS_EXTRACT_TARGET}/fftw3-build)
    
-# removing as this overrides user-specifed prefix
+# removing as this overrides user-specified prefix
 #    set(CMAKE_INSTALL_PREFIX  ${FFTW_EXTERNAL_PATH})
     externalproject_add(OWN_FFTW
     URL ${FFTW_FFTW3_TAR_FILE}

--- a/cmake/BuildFFTW.cmake
+++ b/cmake/BuildFFTW.cmake
@@ -57,7 +57,8 @@ if(NOT FFTW_FOUND)
     set(FFTW_FFTW3_LIB_DIR ${FFTW_EXTERNAL_LIBS_EXTRACT_TARGET}/fftw3)
     set(FFTW_FFTW3_BUILD_DIR ${FFTW_EXTERNAL_LIBS_EXTRACT_TARGET}/fftw3-build)
    
-    set(CMAKE_INSTALL_PREFIX  ${FFTW_EXTERNAL_PATH})
+# removing as this overrides user-specifed prefix
+#    set(CMAKE_INSTALL_PREFIX  ${FFTW_EXTERNAL_PATH})
     externalproject_add(OWN_FFTW
     URL ${FFTW_FFTW3_TAR_FILE}
     URL_MD5 2edab8c06b24feeb3b82bbb3ebf3e7b3

--- a/cmake/BuildFLTK.cmake
+++ b/cmake/BuildFLTK.cmake
@@ -41,7 +41,8 @@ if(NOT FLTK_FOUND)
     set(FLTK_LIB_DIR ${FLTK_EXTERNAL_LIBS_EXTRACT_TARGET}/fltk)
     set(FLTK_BUILD_DIR ${FLTK_EXTERNAL_LIBS_EXTRACT_TARGET}/fltk-build)
    
-    set(CMAKE_INSTALL_PREFIX  ${FLTK_EXTERNAL_PATH})
+# removing as this overrides user-specified prefix
+#    set(CMAKE_INSTALL_PREFIX  ${FLTK_EXTERNAL_PATH})
     externalproject_add(OWN_FLTK
     URL ${FLTK_TAR_FILE}
 #   TIMEOUT 15


### PR DESCRIPTION
Minor changes to cmake scripts that honour the CMAKE_INSTALL_PREFIX which the user can send to cmake.
This allows shared fftw library to be be built and installed to the correct location with 'make install' - rather than assuming the original source directory is available across the cluster (for example).