### PR TITLE
Calling relion_refine w/o args gives flags

### DIFF
--- a/src/ml_optimiser.cpp
+++ b/src/ml_optimiser.cpp
@@ -111,6 +111,12 @@ void MlOptimiser::read(int argc, char **argv, int rank)
 		parseInitial(argc, argv);
 	}
 
+	if(argc==1 || checkParameter(argc, argv, "--help") || checkParameter(argc, argv, "-h"))
+	{
+		usage();
+		exit(0);
+	}
+
 }
 
 void MlOptimiser::parseContinue(int argc, char **argv)


### PR DESCRIPTION
The default call to usage() on ERROR report was disabled, but that
also means that the typical way of getting the flags was lost. This
fixes that by checking for

1. 	no flags
2. 	--help
3. 	-h

All the above three produces calls to usage()