### PR TITLE
fixed installation instructions and markdown formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ make install
  "sudo make install" instead of "make install" in the last step.)
 
 These steps will download the source-code, create a build-directory,
-then configure and build relion, and lastely install it to be generally
+then configure and build relion, and lastly install it to be generally
 available on the system.
 
 

--- a/README.md
+++ b/README.md
@@ -46,10 +46,11 @@ cmake -DCMAKE_INSTALL_PREFIX=/where/to/install/ ..
 make -j4
 make install
 ```
-(NOTE: "/where/to/install/ .." is typically "/usr/local/relion"
+(NOTES: "/where/to/install/ .." is typically "/usr/local/relion".
  Make sure you create this directory beforehand.
- You can do this using "sudo mkdir /usr/local/relion".  In that case, be sure
- to use "sudo make install" instead of "make install" in the last step.)
+ You can do this using "sudo mkdir /usr/local/relion".
+ Installing to that location requires sudo, so in this case be sure to use
+ "sudo make install" instead of "make install" in the last step.)
 
 These steps will download the source-code, create a build-directory,
 then configure and build relion, and lastely install it to be generally
@@ -67,6 +68,6 @@ cd relion
 git pull
 cd build
 make -j4
-make
+make install  # or "sudo make install"
 
 ```

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ More extensive options and configurations are available
 but the outlines to clone and install relion for typical use are made easy
 through [cmake](https://en.wikipedia.org/wiki/CMake).
 
-On ubuntu machines, installing cmake is as easy as
+On ubuntu machines, installing cmake, the compiler, and additional dependencies (mpi, fftw) is as easy as:
 
 ```
 sudo apt install cmake build-essential mpi-default-bin mpi-default-dev libfftw3-dev

--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@
 #RELION
 
 
-RELION (for REgularised LIkelihood OptimisatioN) is a stand-alone computer 
-program for Maximum A Posteriori refinement of (multiple) 3D reconstructions 
-or 2D class averages in cryo-electron microscopy. It is developed in the 
-research group of Sjors Scheres at the MRC Laboratory of Molecular Biology. 
+RELION (for REgularised LIkelihood OptimisatioN) is a stand-alone computer
+program for Maximum A Posteriori refinement of (multiple) 3D reconstructions
+or 2D class averages in cryo-electron microscopy. It is developed in the
+research group of Sjors Scheres at the MRC Laboratory of Molecular Biology.
 
 The underlying theory of MAP refinement is given in a [scientific publication](https://www.ncbi.nlm.nih.gov/pubmed/22100448)
-. If RELION is useful in your work, please cite this paper. 
+. If RELION is useful in your work, please cite this paper.
 
 
 The more comprehensive documentation of RELION is stored on the [Wiki](http://www2.mrc-lmb.cam.ac.uk/relion)
@@ -17,15 +17,15 @@ The more comprehensive documentation of RELION is stored on the [Wiki](http://ww
 ##Installation
 
 
-More extensive options and configurations are available 
+More extensive options and configurations are available
 [here](http://www2.mrc-lmb.cam.ac.uk/relion/index.php/Download_%26_install),
-but the outlines to clone and install relion for typical use are made easy 
+but the outlines to clone and install relion for typical use are made easy
 through [cmake](https://en.wikipedia.org/wiki/CMake).
 
-On ubuntu machines, installing cmake is as easy as 
+On ubuntu machines, installing cmake is as easy as
 
 ```
-sudo apt install cmake
+sudo apt install cmake build-essential mpi-default-bin mpi-default-dev libfftw3-dev
 ```
 
 On other systems it is typically just as easy, you simply have to modify "apt" to
@@ -47,12 +47,12 @@ make -j4
 make install
 ```
 
-These steps will download the source-code, create a build-directory, 
+These steps will download the source-code, create a build-directory,
 then configure and build relion, and lastely install it to be generally
 available on the system.
 
 
-##Updating 
+##Updating
 
 
 RELION is intermittently updated, with both minor and major features.

--- a/README.md
+++ b/README.md
@@ -42,11 +42,11 @@ git clone https://github.com/3dem/relion.git
 cd relion
 mkdir build
 cd build
-cmake -DCMAKE_INSTALL_PREFIX=/where/to/install/ ..
+cmake -DCMAKE_INSTALL_PREFIX=/where/to/install/..
 make -j4
 make install
 ```
-(NOTES: "/where/to/install/ .." is typically "/usr/local/relion".
+(NOTES: "/where/to/install/.." is typically "/usr/local/relion".
  Make sure you create this directory beforehand.
  Installing to that location requires sudo, so in this case be sure to use
  "sudo make install" instead of "make install" in the last step.)

--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ make install
 ```
 (NOTES: "/where/to/install/ .." is typically "/usr/local/relion".
  Make sure you create this directory beforehand.
- You can do this using "sudo mkdir /usr/local/relion".
  Installing to that location requires sudo, so in this case be sure to use
  "sudo make install" instead of "make install" in the last step.)
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,6 @@ cd relion
 git pull
 cd build
 make -j4
-make install  # or "sudo make install"
+make install    # (or "sudo make install")
 
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 
 
-#RELION
+# RELION
 
 
 RELION (for REgularised LIkelihood OptimisatioN) is a stand-alone computer
@@ -14,7 +14,7 @@ The underlying theory of MAP refinement is given in a [scientific publication](h
 
 The more comprehensive documentation of RELION is stored on the [Wiki](http://www2.mrc-lmb.cam.ac.uk/relion)
 
-##Installation
+## Installation
 
 
 More extensive options and configurations are available
@@ -46,21 +46,26 @@ cmake -DCMAKE_INSTALL_PREFIX=/where/to/install/ ..
 make -j4
 make install
 ```
+(NOTE: "/where/to/install/ .." is typically "/usr/local/relion"
+ Make sure you create this directory beforehand.
+ You can do this using "sudo mkdir /usr/local/relion".  In that case, be sure
+ to use "sudo make install" instead of "make install" in the last step.)
 
 These steps will download the source-code, create a build-directory,
 then configure and build relion, and lastely install it to be generally
 available on the system.
 
 
-##Updating
+## Updating
 
 
 RELION is intermittently updated, with both minor and major features.
 To update an existing installation, simply use the following commands
 
 ```
-cd relion/build
+cd relion
 git pull
+cd build
 make -j4
 make
 


### PR DESCRIPTION
A member of our lab was unable to follow the installation instructions in the README.md, and I took this opportunity to change the README.md file in the places where he was stuck. (Specifically, you need to install several other packages besides cmake and git, specifically the packages which include: g++, mpi, and fftw) These changes were tested with ubuntu16.04