### PR TITLE
added missing write(DO_LOCK)

### DIFF
--- a/src/pipeliner.cpp
+++ b/src/pipeliner.cpp
@@ -886,6 +886,7 @@ bool PipeLine::markAsFinishedJob(int this_job, std::string &error_message)
 		{
 			error_message = "You are trying to mark a relion_refine job as finished that hasn't even started. \n This will be ignored. Perhaps you wanted to delete it instead?";
 			processList[this_job].status = PROC_RUNNING;
+	                write(DO_LOCK);
 			return false;
 		}
 	}


### PR DESCRIPTION
When trying to mark a not yet started job as finished, relion doesn't release the lock file for the default_pipeline.star. I added a write(DO_LOCK) before the return statement in order to release the lock in this case.