### PR TITLE
Don't link non-GUI apps against X11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,16 +1,7 @@
-cmake_minimum_required(VERSION 2.8.12)
-set(RELION_CMAKE_MINIMUM_REQUIRED_VERSION "2.8.12")
+cmake_minimum_required(VERSION 3.3)
+set(RELION_CMAKE_MINIMUM_REQUIRED_VERSION "3.3")
 
-#
-#if(POLICY CMP0048)
-#  cmake_policy(SET CMP0048 NEW)
-#endif()
 project(Relion)
-
-# Use new policy for OS X @rpath
-if(POLICY CMP0042)
-    cmake_policy(SET CMP0042 NEW)
-endif()
 
 # Add the path to the additional Find<module>.cmake files 
 # which are included with the distributed RLEION-code

--- a/src/apps/CMakeLists.txt
+++ b/src/apps/CMakeLists.txt
@@ -8,31 +8,41 @@ find_path (X11_INCLUDES Xdbe.h)
 message(STATUS "CMAKE_BINARY_DIR:" ${CMAKE_BINARY_DIR})
 
 file(GLOB REL_SRC "${CMAKE_SOURCE_DIR}/src/*.cpp" "${CMAKE_SOURCE_DIR}/src/*.c" "${CMAKE_SOURCE_DIR}/src/gpu_utils/*.cpp")
+file(GLOB REL_GUI_SRC "${CMAKE_SOURCE_DIR}/src/manualpicker.cpp" "${CMAKE_SOURCE_DIR}/src/gui_*.cpp" "${CMAKE_SOURCE_DIR}/src/displayer.cpp")
+# Remove GUI files from relion_lib
+foreach(GUI_SRC_FILE ${REL_GUI_SRC})
+	list(REMOVE_ITEM REL_SRC "${GUI_SRC_FILE}")
+endforeach()
 file(GLOB REL_SRC_H "${CMAKE_SOURCE_DIR}/src/*.h" "${CMAKE_SOURCE_DIR}/src/gpu_utils/*.h")
 file(GLOB REL_HP "${CMAKE_SOURCE_DIR}/src/Healpix_2.15a/*.cc")
 
 file(GLOB RELION_TARGETS "${CMAKE_SOURCE_DIR}/src/apps/*.cpp")
 
+set(GUI_TARGETS display maingui manualpick pipeliner)
+
 #--Remove apps using X11 if no GUI--
 if(NOT GUI)
-    list(REMOVE_ITEM REL_SRC "${CMAKE_SOURCE_DIR}/src/manualpicker.cpp")
-    list(REMOVE_ITEM REL_SRC "${CMAKE_SOURCE_DIR}/src/gui_entries.cpp")
-    list(REMOVE_ITEM REL_SRC "${CMAKE_SOURCE_DIR}/src/gui_jobwindow.cpp")
-    list(REMOVE_ITEM REL_SRC "${CMAKE_SOURCE_DIR}/src/gui_mainwindow.cpp")
-    list(REMOVE_ITEM REL_SRC "${CMAKE_SOURCE_DIR}/src/displayer.cpp")
-    list(REMOVE_ITEM RELION_TARGETS "${CMAKE_SOURCE_DIR}/src/apps/display.cpp")
-    list(REMOVE_ITEM RELION_TARGETS "${CMAKE_SOURCE_DIR}/src/apps/maingui.cpp")
-    list(REMOVE_ITEM RELION_TARGETS "${CMAKE_SOURCE_DIR}/src/apps/manualpick.cpp")
-    list(REMOVE_ITEM RELION_TARGETS "${CMAKE_SOURCE_DIR}/src/apps/pipeliner.cpp")
+    foreach(TARGET ${GUI_TARGETS})
+        list(REMOVE_ITEM RELION_TARGETS "${CMAKE_SOURCE_DIR}/src/apps/${TARGET}.cpp")
+    endforeach()
 endif(NOT GUI)
 
 
 # relion_lib is STATIC or SHARED type based on BUILD_SHARED_LIBS=ON/OFF
+# relion_lib only contains non-X11 parts
+# relion_gui_lib is where the X11 code is placed
 if(BUILD_SHARED_LIBS)
     add_library(relion_lib SHARED ${REL_SRC} ${REL_SRC_H} ${REL_HP})
     install(TARGETS relion_lib LIBRARY DESTINATION lib)
+    if(GUI)
+        add_library(relion_gui_lib SHARED ${REL_GUI_SRC} ${REL_SRC_H} ${REL_HP})
+        install(TARGETS relion_gui_lib LIBRARY DESTINATION lib)
+    endif(GUI)
 else()
     add_library(relion_lib STATIC ${REL_SRC} ${REL_SRC_H} ${REL_HP})
+    if(GUI)
+        add_library(relion_gui_lib STATIC ${REL_GUI_SRC} ${REL_SRC_H} ${REL_HP})
+    endif(GUI)
 endif()
 
 target_link_libraries(relion_lib ${FFTW_LIBRARIES})
@@ -41,9 +51,10 @@ if(BUILD_OWN_FFTW)
 endif()
 
 if(GUI)
-    target_link_libraries(relion_lib ${FLTK_LIBRARIES})
+    include_directories("${FLTK_INCLUDE_DIR}")
+    target_link_libraries(relion_gui_lib relion_lib ${FLTK_LIBRARIES})
     if(BUILD_OWN_FLTK)
-        add_dependencies(relion_lib OWN_FLTK)
+        add_dependencies(relion_gui_lib OWN_FLTK)
     endif()
 endif(GUI)
 
@@ -101,10 +112,10 @@ foreach (_target ${RELION_TARGETS})
 	    target_link_libraries(${_target} relion_gpu_util)
 	endif(CUDA_FOUND)
 	
-	if(GUI)
-        include_directories("${FLTK_INCLUDE_DIR}")
-		target_link_libraries(${_target} ${FLTK_LIBRARIES} ${X11})
-	endif(GUI)
+	if(${_target} IN_LIST GUI_TARGETS)
+        add_dependencies(${_target} relion_gui_lib)
+		target_link_libraries(${_target} relion_gui_lib ${FLTK_LIBRARIES} ${X11})
+	endif()
 	
 	message(STATUS "added ${_target}...")
 	


### PR DESCRIPTION
When compiling Relion with the default `DGUI=ON`, it links all of the applications in the suite against X11, even apps like `relion_refine` which do not depend on any X11 features. This causes an issue on some batch clusters/supercomputers as X11 is often not present on compute nodes.

This PR introduces a new convenience library, `relion_gui_lib` which contains only the GUI parts and removes them from `relion_lib`.

This allows the relion GUI application to link against X11 etc. while, e.g., relion_refine to be free of X11 dependencies.

It also increases the minimum version of CMake to 3.3 as it uses the [`if(... IN_LIST ...)`](https://cmake.org/cmake/help/v3.8/command/if.html) syntax.