### PR TITLE
Fixed overflow bug caused by relion_MPI_Bcast

### DIFF
--- a/src/ml_optimiser_mpi.h
+++ b/src/ml_optimiser_mpi.h
@@ -23,15 +23,7 @@
 #include "src/mpi.h"
 #include "src/ml_optimiser.h"
 
-#define MPITAG_JOB_REQUEST 0
-#define MPITAG_JOB_REPLY 1
-#define MPITAG_METADATA 2
-#define MPITAG_RANDOMSEED 3
-#define MPITAG_IMAGE 4
-#define MPITAG_PACK 5
-#define MPITAG_RFLOAT 6
-#define MPITAG_INT 7
-#define MPITAG_IDENTIFIER 8
+// definition of MPITAG has been moved to header mpi.h
 
 class MlOptimiserMpi: public MlOptimiser
 {

--- a/src/mpi.cpp
+++ b/src/mpi.cpp
@@ -266,7 +266,7 @@ int MpiNode::relion_MPI_Bcast(void *buffer, long int count, MPI_Datatype datatyp
     if (totalsize <= blocksize) {
         // maximum amount of data can be sent by MPI_Bcast
         // 2 * 1024 * 1024 * 1024 - 1 = 2^31 - 1 = 2147483647 bytes
-        result = MPI_Bcast(buffer, (int)count, datatype, root, comm);
+        result = MPI_Bcast(buffer, static_cast<int>(count), datatype, root, comm);
         if (result != MPI_SUCCESS) {
             report_MPI_ERROR(result);
         }

--- a/src/mpi.h
+++ b/src/mpi.h
@@ -52,6 +52,17 @@
 #include "src/error.h"
 #include "src/macros.h"
 
+#define MPITAG_JOB_REQUEST 0
+#define MPITAG_JOB_REPLY 1
+#define MPITAG_METADATA 2
+#define MPITAG_RANDOMSEED 3
+#define MPITAG_IMAGE 4
+#define MPITAG_PACK 5
+#define MPITAG_RFLOAT 6
+#define MPITAG_INT 7
+#define MPITAG_IDENTIFIER 8
+#define MPITAG_BCAST 9
+
  /** Class to wrapp some MPI common calls in an work node.
  *
  */
@@ -87,7 +98,7 @@ public:
 
     int relion_MPI_Recv(void *buf, std::ptrdiff_t count, MPI_Datatype datatype, int source, int tag, MPI_Comm comm, MPI_Status &status);
 
-    int relion_MPI_Bcast(void *buffer, int count, MPI_Datatype datatype, int root, MPI_Comm comm);
+    int relion_MPI_Bcast(void *buffer, long int count, MPI_Datatype datatype, int root, MPI_Comm comm);
 
     /* Better error handling of MPI error messages */
     void report_MPI_ERROR(int error_code);


### PR DESCRIPTION
(1) Modify type of `count` arguments from `int` to `long int`/`std::ptrdiff_t` for relion_MPI_Bcast().
(2) Reimplement `relion_MPI_Bcast()`. If `count` is smaller than a certain size (1 GB), broadcast data to each slave directly. If `count` is larger than this threshold, data is sent to each slave by `relion_MPI_send()` and `relion_MPI_Recv()`.
