### PR TITLE
Register build byproducts for FFTW external.

### DIFF
--- a/cmake/BuildFFTW.cmake
+++ b/cmake/BuildFFTW.cmake
@@ -85,6 +85,13 @@ else()
 	#	LOG_BUILD
 	LOG_INSTALL)
 	
+
+	add_custom_command(
+		COMMAND ${CMAKE_COMMAND} -E echo "Registering own FFTW byproducts"
+		OUTPUT "${FFTW_EXTERNAL_PATH}/lib/libfftw3.so"
+		DEPENDS own_fftw_lib)
+	add_custom_target(own_fftw_lib_byproducts
+		DEPENDS "${FFTW_EXTERNAL_PATH}/lib/libfftw3.so")
 	
 	if (FFTW_DOUBLE_REQUIRED AND FFTW_SINGLE_REQUIRED)
 		
@@ -102,6 +109,13 @@ else()
 		LOG_INSTALL)
 	
 		add_dependencies(own_fftwf_lib own_fftw_lib)
+
+		add_custom_command(
+			COMMAND ${CMAKE_COMMAND} -E echo "Registering own FFTWf byproducts"
+			OUTPUT "${FFTW_EXTERNAL_PATH}/lib/libfftw3f.so"
+			DEPENDS own_fftwf_lib)
+		add_custom_target(own_fftwf_lib_byproducts
+			DEPENDS "${FFTW_EXTERNAL_PATH}/lib/libfftw3f.so")
 	endif()
 
 endif()


### PR DESCRIPTION
If an external project is used for FFTW / FFTWF, Relion links libraries directly against the resulting libraries (such as `libfftw3f.so`).

Some build generators (specifically, Ninja) require that the full dependency graph is calculated at the beginning of the build process.  Since the file `libfftw3f.so` does not exist at the beginning of the build (the `ExternalProject` command has not been run yet) -- and there is no rule to generate that file -- the build fails.

With this change, we introduce a fake target that relies on the `ExternalProject` and has as a build byproduct the resulting library. This allows `ninja` to correctly resolve the dependency and build Relion.