### PR TITLE
Added libjpeg installation check.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -354,6 +354,7 @@ find_package(PNG)
 if(PNG_FOUND)
 	add_definitions(-DHAVE_PNG)
 endif()
+find_package(JPEG)
 
 # ----------------------------------------------------------------------COPY SCRIPTS--
 


### PR DESCRIPTION
On systems without libjpeg installed, the following compile-time error occurs during make.

> :
> Building C object src/apps/CMakeFiles/relion_lib.dir/__/jaz/d3x3/dsytrd3.c.o
> In file included from /usr/local/src/relion/src/jaz/gravis/tImage.h:295:0,
>                  from /usr/local/src/relion/src/jaz/img_proc/color_helper.cpp:6:
> /usr/local/src/relion/src/jaz/gravis/private/tImageIO_JPG.hxx:14:21: fatal error
>  #include <jpeglib.h>
>                      ^
> compilation terminated.
> : 
> 
>

I was wondering where to write CMakeList.txt, but I wrote it here.
I will fix it if you can tell me.
