### PR TITLE
PORT: bring FFT stuff to GPU for backprojection

### DIFF
--- a/src/acc/utilities.h
+++ b/src/acc/utilities.h
@@ -150,6 +150,19 @@ static T getSumOnDevice(AccPtr<T> &ptr)
 }
 
 template <typename T>
+static void getSumOnDeviceSingleBlock(AccPtr<T> &ptr, T *sum)
+{
+#ifdef CUDA
+	CudaKernels::getSumOnDeviceSingleBlock<T>(ptr, sum);
+#else
+	size_t size = ptr.getSize();
+	*sum = 0;
+	for (size_t i=0; i<size; i++)
+		*sum += ptr[i];
+#endif
+}
+
+template <typename T>
 static T getMinOnDevice(AccPtr<T> &ptr)
 {
 #ifdef CUDA
@@ -178,6 +191,16 @@ static T getMaxOnDevice(AccPtr<T> &ptr)
 		printf("DEBUG_ERROR: getMaxOnDevice called with null device pointer.\n");
 #endif
 	return CpuKernels::getMax<T>(ptr(), ptr.getSize());
+#endif
+}
+
+template <typename T>
+static void getMaxOnDeviceSingleBlock(AccPtr<T> &ptr, T* max_val)
+{
+#ifdef CUDA
+	CudaKernels::getMaxOnDeviceSingleBlock<T>(ptr, max_val);
+#else
+	*max_val = CpuKernels::getMax<T>(ptr(), ptr.getSize());
 #endif
 }
 
@@ -311,7 +334,7 @@ static void cosineFilter(
 		XFLOAT radius,
 		XFLOAT radius_p,
 		XFLOAT cosine_width,
-		XFLOAT sum_bg_total);
+		AccPtr<XFLOAT> &sum_bg);
 
 template<bool DATA3D>
 void powerClass(int		in_gridSize,

--- a/src/ml_optimiser_mpi.cpp
+++ b/src/ml_optimiser_mpi.cpp
@@ -2085,7 +2085,8 @@ void MlOptimiserMpi::maximization()
 								mymodel.tau2_fudge_factor,
 								wsum_model.pdf_class[iclass],
 								minres_map,
-								false
+								false,
+								do_gpu
 							);
 						}
 						if (do_sgd)

--- a/src/tabfuncs.h
+++ b/src/tabfuncs.h
@@ -68,7 +68,15 @@ public:
         return *this;
     }
 
+	size_t getSize()
+	{
+		return XSIZE(tabulatedValues);
+	}
 
+	RFLOAT* getReference()
+	{
+		return MULTIDIM_ARRAY(tabulatedValues);
+	}	
 };
 
 class TabSine : public TabFunction


### PR DESCRIPTION
this PR brings cuFFT for the `back-projection` stage. We also optimized data locality and removed some redundant sync points.