### PR TITLE
Updated code with inclusive terms leader and follower

### DIFF
--- a/src/autopicker_mpi.cpp
+++ b/src/autopicker_mpi.cpp
@@ -25,17 +25,17 @@ void AutoPickerMpi::read(int argc, char **argv)
 	// Define a new MpiNode
 	node = new MpiNode(argc, argv);
 
-	if (node->isMaster())
+	if (node->isLeader())
 		PRINT_VERSION_INFO();
 
 	// First read in non-parallelisation-dependent variables
 	AutoPicker::read(argc, argv);
 
-	// Don't put any output to screen for mpi slaves
-	if (!node->isMaster())
+	// Don't put any output to screen for mpi followers
+	if (!node->isLeader())
 		verb = 0;
 
-	if (do_write_fom_maps && node->isMaster())
+	if (do_write_fom_maps && node->isLeader())
 		std::cerr << "WARNING : --write_fom_maps is very heavy on disc I/O and is not advised in parallel execution. If possible, using --shrink 0 and lowpass makes I/O less significant." << std::endl;
 
 	// Possibly also read parallelisation-dependent variables here
@@ -60,9 +60,9 @@ int AutoPickerMpi::deviceInitialise()
 	else
 		dev_id = textToInteger((allThreadIDs[node->rank][0]).c_str());
 
-	for (int slave = 0; slave < node->size; slave++)
+	for (int follower = 0; follower < node->size; follower++)
 	{
-		if (slave == node->rank)
+		if (follower == node->rank)
 		{
 			std::cout << " + Using GPU device: " << dev_id << " on MPI node: " << node->rank << std::endl;
 			std::cout.flush();

--- a/src/ctffind_runner_mpi.cpp
+++ b/src/ctffind_runner_mpi.cpp
@@ -27,8 +27,8 @@ void CtffindRunnerMpi::read(int argc, char **argv)
 	// First read in non-parallelisation-dependent variables
 	CtffindRunner::read(argc, argv);
 
-	// Don't put any output to screen for mpi slaves
-	verb = (node->isMaster()) ? 1 : 0;
+	// Don't put any output to screen for mpi followers
+	verb = (node->isLeader()) ? 1 : 0;
 
 	// Possibly also read parallelisation-dependent variables here
 
@@ -98,8 +98,8 @@ void CtffindRunnerMpi::run()
 
 	MPI_Barrier(MPI_COMM_WORLD);
 
-	// Only the master writes the joined result file
-	if (node->isMaster())
+	// Only the leader writes the joined result file
+	if (node->isLeader())
 	{
 		joinCtffindResults();
 	}

--- a/src/jaz/ctf/ctf_refiner_mpi.cpp
+++ b/src/jaz/ctf/ctf_refiner_mpi.cpp
@@ -28,8 +28,8 @@ void CtfRefinerMpi::read(int argc, char **argv)
     // First read in non-parallelisation-dependent variables
     CtfRefiner::read(argc, argv);
 
-    // Don't put any output to screen for mpi slaves
-    verb = (node->isMaster()) ? verb : 0;
+    // Don't put any output to screen for mpi followers
+    verb = (node->isLeader()) ? verb : 0;
 
     // Possibly also read parallelisation-dependent variables here
 	if (node->size < 2)
@@ -51,7 +51,7 @@ void CtfRefinerMpi::run()
 	// Each node does part of the work
 	long int my_first_micrograph, my_last_micrograph;
 	divide_equally(total_nr_micrographs, node->size, node->rank, my_first_micrograph, my_last_micrograph);
-	
+
 	if (do_defocus_fit || do_bfac_fit || do_tilt_fit || do_aberr_fit || do_mag_fit)
     {
     	processSubsetMicrographs(my_first_micrograph, my_last_micrograph);
@@ -59,7 +59,7 @@ void CtfRefinerMpi::run()
 
     MPI_Barrier(MPI_COMM_WORLD);
 
-    if (node->isMaster())
+    if (node->isLeader())
     {
 		finalise();
     }

--- a/src/ml_optimiser_mpi.cpp
+++ b/src/ml_optimiser_mpi.cpp
@@ -53,20 +53,20 @@ void MlOptimiserMpi::read(int argc, char **argv)
     // Define a new MpiNode
     node = new MpiNode(argc, argv);
 
-    if (node->isMaster())
+    if (node->isLeader())
     	PRINT_VERSION_INFO();
 
     // First read in non-parallelisation-dependent variables
     MlOptimiser::read(argc, argv, node->rank);
 
     int mpi_section = parser.addSection("MPI options");
-    halt_all_slaves_except_this = textToInteger(parser.getOption("--halt_all_slaves_except", "For debugging: keep all slaves except this one waiting", "-1"));
+    halt_all_followers_except_this = textToInteger(parser.getOption("--halt_all_followers_except", "For debugging: keep all followers except this one waiting", "-1"));
     do_keep_debug_reconstruct_files  = parser.checkOption("--keep_debug_reconstruct_files", "For debugging: keep temporary data and weight files for debug-reconstructions.");
 
-    // Don't put any output to screen for mpi slaves
+    // Don't put any output to screen for mpi followers
     ori_verb = verb;
     if (verb != 0)
-    	verb = (node->isMaster()) ? ori_verb : 0;
+    	verb = (node->isLeader()) ? ori_verb : 0;
 
 //#define DEBUG_BODIES
 #ifdef DEBUG_BODIES
@@ -118,11 +118,11 @@ void MlOptimiserMpi::initialise()
 
 
 		// ------------------------------ FIGURE OUT GLOBAL DEVICE MAP------------------------------------------
-		if (!node->isMaster())
+		if (!node->isLeader())
 		{
 			cudaDeviceProp deviceProp;
 			int compatibleDevices(0);
-			// Send device count seen by this slave
+			// Send device count seen by this follower
 			HANDLE_ERROR(cudaGetDeviceCount(&devCount));
 			for(int i=0; i<devCount; i++ )
 			{
@@ -142,7 +142,7 @@ void MlOptimiserMpi::initialise()
 
 			node->relion_MPI_Send(&devCount, 1, MPI_INT, 0, MPITAG_INT, MPI_COMM_WORLD);
 
-			// Send host-name seen by this slave
+			// Send host-name seen by this follower
 			char buffer[BUFSIZ];
 			int len;
 			MPI_Get_processor_name(buffer, &len);
@@ -153,18 +153,18 @@ void MlOptimiserMpi::initialise()
 		else
 		{
 
-			for (int slave = 1; slave < node->size; slave++)
+			for (int follower = 1; follower < node->size; follower++)
 			{
-				// Receive device count seen by this slave
-				node->relion_MPI_Recv(&devCount, 1, MPI_INT, slave, MPITAG_INT, MPI_COMM_WORLD, status);
-				deviceCounts[slave] = devCount;
+				// Receive device count seen by this follower
+				node->relion_MPI_Recv(&devCount, 1, MPI_INT, follower, MPITAG_INT, MPI_COMM_WORLD, status);
+				deviceCounts[follower] = devCount;
 
-				// Receive host-name seen by this slave
+				// Receive host-name seen by this follower
 				char buffer[BUFSIZ];
-				node->relion_MPI_Recv(&buffer, BUFSIZ, MPI_CHAR, slave, MPITAG_IDENTIFIER, MPI_COMM_WORLD, status);
+				node->relion_MPI_Recv(&buffer, BUFSIZ, MPI_CHAR, follower, MPITAG_IDENTIFIER, MPI_COMM_WORLD, status);
 				std::string hostName(buffer);
 
-				// push_back unique host names and count slaves on them
+				// push_back unique host names and count followers on them
 				int idi(-1);
 
 				//check for novel host
@@ -172,16 +172,16 @@ void MlOptimiserMpi::initialise()
 					if (uniqueHosts[j] == hostName)
 						idi = j;
 
-				if (idi >= 0)// if known, increment counter and assign host-id to slave
+				if (idi >= 0)// if known, increment counter and assign host-id to follower
 				{
 					ranksOnHost[idi]++;
-					hostId[slave] = idi;
+					hostId[follower] = idi;
 				}
-				else // if unknown, push new name and counter, and assign host-id to slave
+				else // if unknown, push new name and counter, and assign host-id to follower
 				{
 					uniqueHosts.push_back(hostName);
 					ranksOnHost.push_back(1);
-					hostId[slave] = ranksOnHost.size()-1;
+					hostId[follower] = ranksOnHost.size()-1;
 				}
 			}
 		}
@@ -191,7 +191,7 @@ void MlOptimiserMpi::initialise()
 
 
 		// ------------------------------ SET DEVICE INDICES BASED ON HOST DEVICE-COUNTS ------------------------------------------
-		if (node->isMaster())
+		if (node->isLeader())
 		{
 			for (int i = 0; i < uniqueHosts.size(); i++)
 			{
@@ -231,7 +231,7 @@ void MlOptimiserMpi::initialise()
 					fullAutomaticMapping=false;
 					if(allThreadIDs[rank-1].size()!=nr_threads)
 					{
-						std::cout << " Slave " << rank << " will distribute threads over devices ";
+						std::cout << " Follower " << rank << " will distribute threads over devices ";
 						for (int j = 0; j < allThreadIDs[rank-1].size(); j++)
 							std::cout << " "  << allThreadIDs[rank-1][j];
 						std::cout  << std::endl;
@@ -239,7 +239,7 @@ void MlOptimiserMpi::initialise()
 					else
 					{
 						semiAutomaticMapping = false;
-						std::cout << " Using explicit indexing on slave " << rank << " to assign devices ";
+						std::cout << " Using explicit indexing on follower " << rank << " to assign devices ";
 						for (int j = 0; j < allThreadIDs[rank-1].size(); j++)
 							std::cout << " "  << allThreadIDs[rank-1][j];
 						std::cout  << std::endl;
@@ -271,7 +271,7 @@ void MlOptimiserMpi::initialise()
 						dev_id = textToInteger(allThreadIDs[rank-1][i].c_str());
 					}
 
-					std::cout << " Thread " << i << " on slave " << rank << " mapped to device " << dev_id << std::endl;
+					std::cout << " Thread " << i << " on follower " << rank << " mapped to device " << dev_id << std::endl;
 					node->relion_MPI_Send(&dev_id, 1, MPI_INT, rank, MPITAG_INT, MPI_COMM_WORLD);
 				}
 			}
@@ -304,7 +304,7 @@ void MlOptimiserMpi::initialise()
 		MPI_Barrier(MPI_COMM_WORLD);
 
 
-        if (! node->isMaster())
+        if (! node->isLeader())
         {
             int devCount = cudaDevices.size();
             node->relion_MPI_Send(&devCount, 1, MPI_INT, 0, MPITAG_INT, MPI_COMM_WORLD);
@@ -340,16 +340,16 @@ void MlOptimiserMpi::initialise()
 			std::vector<int> uniqueDeviceIdentifierCounts;
 			std::vector<int> deviceCounts(node->size-1,0);
 
-		        for (int slave = 1; slave < node->size; slave++)
+		        for (int follower = 1; follower < node->size; follower++)
 		        {
-	        	node->relion_MPI_Recv(&devCount, 1, MPI_INT, slave, MPITAG_INT, MPI_COMM_WORLD, status);
+	        	node->relion_MPI_Recv(&devCount, 1, MPI_INT, follower, MPITAG_INT, MPI_COMM_WORLD, status);
 
-	        	deviceCounts[slave-1] = devCount;
+	        	deviceCounts[follower-1] = devCount;
 
 				for (int i = 0; i < devCount; i++)
 				{
 					char buffer[BUFSIZ];
-			        	node->relion_MPI_Recv(&buffer, BUFSIZ, MPI_CHAR, slave, MPITAG_IDENTIFIER, MPI_COMM_WORLD, status);
+			        	node->relion_MPI_Recv(&buffer, BUFSIZ, MPI_CHAR, follower, MPITAG_IDENTIFIER, MPI_COMM_WORLD, status);
 					std::string deviceIdentifier(buffer);
 
 					deviceIdentifiers.push_back(deviceIdentifier);
@@ -375,14 +375,14 @@ void MlOptimiserMpi::initialise()
 			for (int i = 0; i < uniqueDeviceIdentifiers.size(); i++)
 				if (uniqueDeviceIdentifierCounts[i] > 1)
 				{
-					std::cout << uniqueDeviceIdentifiers[i] << " is split between " << uniqueDeviceIdentifierCounts[i] << " slaves" << std::endl;
+					std::cout << uniqueDeviceIdentifiers[i] << " is split between " << uniqueDeviceIdentifierCounts[i] << " followers" << std::endl;
 					is_split = true;
 				}
 	        int global_did = 0;
 
-	        for (int slave = 1; slave < node->size; slave++)
+	        for (int follower = 1; follower < node->size; follower++)
 	        {
-	        	devCount = deviceCounts[slave - 1];
+	        	devCount = deviceCounts[follower - 1];
 
 				for (int i = 0; i < devCount; i++)
 				{
@@ -392,7 +392,7 @@ void MlOptimiserMpi::initialise()
 						if (uniqueDeviceIdentifiers[j] == deviceIdentifiers[global_did])
 							idi = j;
 
-					node->relion_MPI_Send(&uniqueDeviceIdentifierCounts[idi], 1, MPI_INT, slave, MPITAG_INT, MPI_COMM_WORLD);
+					node->relion_MPI_Send(&uniqueDeviceIdentifierCounts[idi], 1, MPI_INT, follower, MPITAG_INT, MPI_COMM_WORLD);
 
 					global_did ++;
 				}
@@ -402,7 +402,7 @@ void MlOptimiserMpi::initialise()
 
 		if(do_auto_refine)
 		{
-			if (!node->isMaster())
+			if (!node->isLeader())
 			{
 				unsigned long long boxLim (10000);
 				for (int i = 0; i < cudaDevices.size(); i ++)
@@ -417,9 +417,9 @@ void MlOptimiserMpi::initialise()
 			else
 			{
 				unsigned long long boxLim, LowBoxLim(10000);
-				for(int slave = 1; slave < node->size; slave++)
+				for(int follower = 1; follower < node->size; follower++)
 				{
-					node->relion_MPI_Recv(&boxLim, 1, MPI_UNSIGNED_LONG_LONG, slave, MPITAG_INT, MPI_COMM_WORLD, status);
+					node->relion_MPI_Recv(&boxLim, 1, MPI_UNSIGNED_LONG_LONG, follower, MPITAG_INT, MPI_COMM_WORLD, status);
 					LowBoxLim = (boxLim < LowBoxLim ? boxLim : LowBoxLim );
 				}
 
@@ -440,9 +440,9 @@ from the last completed iteration (i.e. continue from it) *without* the use of G
 
 					if(is_split)
 					{
-						std::cerr << "You are also splitting at least one GPU between two or more mpi-slaves, which \n\
-might be the limiting factor, since each mpi-slave that shares a GPU increases the \n\
-use of memory. In this case we recommend running a single mpi-slave per GPU, which \n\
+						std::cerr << "You are also splitting at least one GPU between two or more mpi-followers, which \n\
+might be the limiting factor, since each mpi-follower that shares a GPU increases the \n\
+use of memory. In this case we recommend running a single mpi-follower per GPU, which \n\
 will still yield good performance and possibly a more stable execution. \n" << std::endl;
 					}
 #ifdef ACC_DOUBLE_PRECISION
@@ -521,7 +521,7 @@ will still yield good performance and possibly a more stable execution. \n" << s
 		calculateSumOfPowerSpectraAndAverageImage(Mavg);
 
 		// Set sigma2_noise and Iref from averaged poser spectra and Mavg
-		if (!node->isMaster())
+		if (!node->isLeader())
 			MlOptimiser::setSigmaNoiseEstimatesAndSetAverageImage(Mavg);
 		//std::cout << " Hello world3! I am node " << node->rank << " out of " << node->size <<" and my hostname= "<< getenv("HOSTNAME")<< std::endl;
 	}
@@ -530,18 +530,18 @@ will still yield good performance and possibly a more stable execution. \n" << s
 	MlOptimiser::initialLowPassFilterReferences();
 
 	// Initialise the data_versus_prior ratio to get the initial current_size right
-	if (iter == 0 && !do_initialise_bodies && !node->isMaster())
+	if (iter == 0 && !do_initialise_bodies && !node->isLeader())
 		mymodel.initialiseDataVersusPrior(fix_tau); // fix_tau was set in initialiseGeneral
 
 	//std::cout << " Hello world! I am node " << node->rank << " out of " << node->size <<" and my hostname= "<< getenv("HOSTNAME")<< std::endl;
 
-	// Only master writes out initial mymodel (do not gather metadata yet)
+	// Only leader writes out initial mymodel (do not gather metadata yet)
 	int my_nr_subsets = (do_split_random_halves) ? 2 : 1;
-	if (node->isMaster())
+	if (node->isLeader())
 		MlOptimiser::write(DONT_WRITE_SAMPLING, DO_WRITE_DATA, DONT_WRITE_OPTIMISER, DONT_WRITE_MODEL, node->rank);
 	else if (node->rank <= my_nr_subsets)
 	{
-		//Only the first_slave of each subset writes model to disc
+		//Only the first_follower of each subset writes model to disc
 		MlOptimiser::write(DO_WRITE_SAMPLING, DONT_WRITE_DATA, DO_WRITE_OPTIMISER, DO_WRITE_MODEL, node->rank);
 
 		bool do_warn = false;
@@ -584,11 +584,11 @@ void MlOptimiserMpi::initialiseWorkLoad()
 	// Get the same random number generator seed for all mpi nodes
 	if (random_seed == -1)
 	{
-		if (node->isMaster())
+		if (node->isLeader())
 		{
 			random_seed = time(NULL);
-		        for (int slave = 1; slave < node->size; slave++)
-	        		node->relion_MPI_Send(&random_seed, 1, MPI_INT, slave, MPITAG_RANDOMSEED, MPI_COMM_WORLD);
+		        for (int follower = 1; follower < node->size; follower++)
+	        		node->relion_MPI_Send(&random_seed, 1, MPI_INT, follower, MPITAG_RANDOMSEED, MPI_COMM_WORLD);
 		}
 		else
 		{
@@ -607,9 +607,9 @@ void MlOptimiserMpi::initialiseWorkLoad()
 		my_halfset = node->myRandomSubset();
 	}
 
-	if (node->isMaster())
+	if (node->isLeader())
 	{
-		// The master never participates in any actual work
+		// The leader never participates in any actual work
 		my_first_particle_id = 0;
 		my_last_particle_id = -1;
 	}
@@ -617,27 +617,27 @@ void MlOptimiserMpi::initialiseWorkLoad()
 	{
 		if (do_split_random_halves)
 		{
-			int nr_slaves_halfset1 = (node->size - 1) / 2;
-			int nr_slaves_halfset2 = nr_slaves_halfset1;
+			int nr_followers_halfset1 = (node->size - 1) / 2;
+			int nr_followers_halfset2 = nr_followers_halfset1;
 			if ((node->size - 1) % 2 != 0)
-				nr_slaves_halfset1 += 1;
+				nr_followers_halfset1 += 1;
 		    	if (node->myRandomSubset() == 1)
 		    	{
 	 			// Divide first half of the images
-				divide_equally(mydata.numberOfParticles(1), nr_slaves_halfset1, node->rank / 2, my_first_particle_id, my_last_particle_id);
+				divide_equally(mydata.numberOfParticles(1), nr_followers_halfset1, node->rank / 2, my_first_particle_id, my_last_particle_id);
 			}
 			else
 			{
 				// Divide second half of the images
-				divide_equally(mydata.numberOfParticles(2), nr_slaves_halfset2, node->rank / 2 - 1, my_first_particle_id, my_last_particle_id);
+				divide_equally(mydata.numberOfParticles(2), nr_followers_halfset2, node->rank / 2 - 1, my_first_particle_id, my_last_particle_id);
 				my_first_particle_id += mydata.numberOfParticles(1);
 				my_last_particle_id += mydata.numberOfParticles(1);
 			}
 		}
 		else
 		{
-			int nr_slaves = (node->size - 1);
-			divide_equally(mydata.numberOfParticles(), nr_slaves, node->rank - 1, my_first_particle_id, my_last_particle_id);
+			int nr_followers = (node->size - 1);
+			divide_equally(mydata.numberOfParticles(), nr_followers, node->rank - 1, my_first_particle_id, my_last_particle_id);
 		}
 	}
 
@@ -652,7 +652,7 @@ void MlOptimiserMpi::initialiseWorkLoad()
 			if (do_parallel_disc_io)
 			{
 				FileName fn_lock = mydata.initialiseScratchLock(fn_scratch, fn_out);
-				// One rank after the other, all slaves pass through mydata.prepareScratchDirectory()
+				// One rank after the other, all followers pass through mydata.prepareScratchDirectory()
 				// This way, only the first rank on each hostname will actually copy the particle stacks
 				// The rest will just update the filenames in exp_model
 				bool need_to_copy = false;
@@ -664,13 +664,13 @@ void MlOptimiserMpi::initialiseWorkLoad()
 					}
 					if (inode > 0 && inode == node->rank)
 					{
-						// The master removes the lock if it existed
+						// The leader removes the lock if it existed
 						need_to_copy = mydata.prepareScratchDirectory(fn_scratch, fn_lock);
 					}
 					MPI_Barrier(MPI_COMM_WORLD);
 				}
 
-				int myverb = (node->rank == 1) ? ori_verb : 0; // Only the first slave
+				int myverb = (node->rank == 1) ? ori_verb : 0; // Only the first follower
 				if (need_to_copy)
 					mydata.copyParticlesToScratch(myverb, true, also_do_ctfimage, keep_free_scratch_Gb);
 
@@ -680,8 +680,8 @@ void MlOptimiserMpi::initialiseWorkLoad()
 			}
 			else
 			{
-				// Only the master needs to copy the data, as only the master will be reading in images
-				if (node->isMaster())
+				// Only the leader needs to copy the data, as only the leader will be reading in images
+				if (node->isLeader())
 				{
 					mydata.prepareScratchDirectory(fn_scratch);
 					mydata.copyParticlesToScratch(1, true, also_do_ctfimage, keep_free_scratch_Gb);
@@ -698,7 +698,7 @@ void MlOptimiserMpi::initialiseWorkLoad()
 
 	if(!do_split_random_halves)
 	{
-		if(!node->isMaster())
+		if(!node->isLeader())
 		{
 			/* Set up a bool-array with reference responsibilities for each rank. That is;
 			 * if(PPrefRank[i]==true)  //on this rank
@@ -756,7 +756,7 @@ void MlOptimiserMpi::expectation()
 #endif
 
 	MultidimArray<long int> first_last_nr_images(6);
-	int first_slave = 1;
+	int first_follower = 1;
 	// Use maximum of 100 particles for 3D and 10 particles for 2D estimations
 	int n_trials_acc = (mymodel.ref_dim==3 && mymodel.data_dim != 3) ? 100 : 10;
 	n_trials_acc = XMIPP_MIN(n_trials_acc, mydata.numberOfParticles());
@@ -772,11 +772,11 @@ void MlOptimiserMpi::expectation()
 	updateImageSizeAndResolutionPointers();
 
 	// B. Set the PPref Fourier transforms, initialise wsum_model, etc.
-	// The master only holds metadata, it does not set up the wsum_model (to save memory)
+	// The leader only holds metadata, it does not set up the wsum_model (to save memory)
 #ifdef TIMING
 	timer.tic(TIMING_EXP_1a);
 #endif
-	if (!node->isMaster())
+	if (!node->isLeader())
 	{
 		MlOptimiser::expectationSetup();
 
@@ -794,11 +794,11 @@ void MlOptimiserMpi::expectation()
 
 	if(!do_split_random_halves)
 	{
-		if (!node->isMaster())
+		if (!node->isLeader())
 		{
 			for(int i=0; i<mymodel.PPref.size(); i++)
 			{
-				/* NOTE: the first slave has rank 0 on the slave communicator node->slaveC,
+				/* NOTE: the first follower has rank 0 on the follower communicator node->followerC,
 				 *       that's why we don't have to add 1, like this;
 				 *       int sender = (i)%(node->size - 1)+1 ;
 				 */
@@ -806,15 +806,15 @@ void MlOptimiserMpi::expectation()
 				int sender = (i)%(node->size - 1); // which rank did the heavy lifting? -> sender of information
 				{
 #ifdef MPI_DEBUG
-					std::cout << "relion_MPI_Bcast debug: rank = " << node->rank << " i = " << i << " MULTIDIM_SIZE(mymodel.PPref[i].data) = " << MULTIDIM_SIZE(mymodel.PPref[i].data) << " sender = " << sender << " slaveC = " << node->slaveC << std::endl;
+					std::cout << "relion_MPI_Bcast debug: rank = " << node->rank << " i = " << i << " MULTIDIM_SIZE(mymodel.PPref[i].data) = " << MULTIDIM_SIZE(mymodel.PPref[i].data) << " sender = " << sender << " followerC = " << node->followerC << std::endl;
 #endif
-					// Communicating over all slaves means we don't have to allocate on the master.
+					// Communicating over all followers means we don't have to allocate on the leader.
 					node->relion_MPI_Bcast(MULTIDIM_ARRAY(mymodel.PPref[i].data),
-					                       MULTIDIM_SIZE(mymodel.PPref[0].data), MY_MPI_COMPLEX, sender, node->slaveC);
+					                       MULTIDIM_SIZE(mymodel.PPref[0].data), MY_MPI_COMPLEX, sender, node->followerC);
 					// For multibody refinement with overlapping bodies, there may be more PPrefs than bodies!
 					if (i < mymodel.nr_classes * mymodel.nr_bodies)
 						node->relion_MPI_Bcast(MULTIDIM_ARRAY(mymodel.tau2_class[i]),
-						                       MULTIDIM_SIZE(mymodel.tau2_class[0]), MY_MPI_DOUBLE, sender, node->slaveC);
+						                       MULTIDIM_SIZE(mymodel.tau2_class[0]), MY_MPI_DOUBLE, sender, node->followerC);
 				}
 			}
 		}
@@ -842,26 +842,26 @@ void MlOptimiserMpi::expectation()
 #endif
 	// C. Calculate expected angular errors
 	// Do not do this for maxCC
-	// Only the first (reconstructing) slave (i.e. from half1) calculates expected angular errors
+	// Only the first (reconstructing) follower (i.e. from half1) calculates expected angular errors
 	if (!(iter==1 && do_firstiter_cc) && !(do_skip_align || do_skip_rotate) && !do_sgd)
 	{
 		int my_nr_images, length_fn_ctf;
-		if (node->isMaster())
+		if (node->isLeader())
 		{
-			// Master sends metadata (but not imagedata) for first 100 particles to first_slave (for calculateExpectedAngularErrors)
+			// Leader sends metadata (but not imagedata) for first 100 particles to first_follower (for calculateExpectedAngularErrors)
 			MlOptimiser::getMetaAndImageDataSubset(0, n_trials_acc-1, false);
 			my_nr_images = YSIZE(exp_metadata);
-			node->relion_MPI_Send(&my_nr_images, 1, MPI_INT, first_slave, MPITAG_JOB_REQUEST, MPI_COMM_WORLD);
-			node->relion_MPI_Send(MULTIDIM_ARRAY(exp_metadata), MULTIDIM_SIZE(exp_metadata), MY_MPI_DOUBLE, first_slave, MPITAG_METADATA, MPI_COMM_WORLD);
+			node->relion_MPI_Send(&my_nr_images, 1, MPI_INT, first_follower, MPITAG_JOB_REQUEST, MPI_COMM_WORLD);
+			node->relion_MPI_Send(MULTIDIM_ARRAY(exp_metadata), MULTIDIM_SIZE(exp_metadata), MY_MPI_DOUBLE, first_follower, MPITAG_METADATA, MPI_COMM_WORLD);
 			// Also send exp_fn_ctfs if necessary
 			length_fn_ctf = exp_fn_ctf.length() + 1; // +1 to include \0 at the end of the string
-			node->relion_MPI_Send(&length_fn_ctf, 1, MPI_INT, first_slave, MPITAG_JOB_REQUEST, MPI_COMM_WORLD);
+			node->relion_MPI_Send(&length_fn_ctf, 1, MPI_INT, first_follower, MPITAG_JOB_REQUEST, MPI_COMM_WORLD);
 			if (length_fn_ctf > 1)
-				node->relion_MPI_Send((void*)exp_fn_ctf.c_str(), length_fn_ctf, MPI_CHAR, first_slave, MPITAG_METADATA, MPI_COMM_WORLD);
+				node->relion_MPI_Send((void*)exp_fn_ctf.c_str(), length_fn_ctf, MPI_CHAR, first_follower, MPITAG_METADATA, MPI_COMM_WORLD);
 		}
-		else if (node->rank == first_slave)
+		else if (node->rank == first_follower)
 		{
-			// Slave has to receive all metadata from the master!
+			// Follower has to receive all metadata from the leader!
 			node->relion_MPI_Recv(&my_nr_images, 1, MPI_INT, 0, MPITAG_JOB_REQUEST, MPI_COMM_WORLD, status);
 			exp_metadata.resize(my_nr_images, METADATA_LINE_LENGTH_BEFORE_BODIES + (mymodel.nr_bodies) * METADATA_NR_BODY_PARAMS);
 			node->relion_MPI_Recv(MULTIDIM_ARRAY(exp_metadata), MULTIDIM_SIZE(exp_metadata), MY_MPI_DOUBLE, 0, MPITAG_METADATA, MPI_COMM_WORLD, status);
@@ -877,40 +877,40 @@ void MlOptimiserMpi::expectation()
 			calculateExpectedAngularErrors(0, n_trials_acc-1);
 		}
 
-		// The reconstructing slave Bcast acc_rottilt, acc_psi, acc_trans to all other nodes!
-		node->relion_MPI_Bcast(&acc_rot, 1, MY_MPI_DOUBLE, first_slave, MPI_COMM_WORLD);
-		node->relion_MPI_Bcast(&acc_trans, 1, MY_MPI_DOUBLE, first_slave, MPI_COMM_WORLD);
+		// The reconstructing follower Bcast acc_rottilt, acc_psi, acc_trans to all other nodes!
+		node->relion_MPI_Bcast(&acc_rot, 1, MY_MPI_DOUBLE, first_follower, MPI_COMM_WORLD);
+		node->relion_MPI_Bcast(&acc_trans, 1, MY_MPI_DOUBLE, first_follower, MPI_COMM_WORLD);
 	}
 #ifdef TIMING
 		timer.toc(TIMING_EXP_2);
 		timer.tic(TIMING_EXP_3);
 #endif
-	// D. Update the angular sampling (all nodes except master)
-	if (!node->isMaster() && ( (do_auto_refine || do_sgd) && iter > 1) || (mymodel.nr_classes > 1 && allow_coarser_samplings) )
+	// D. Update the angular sampling (all nodes except leader)
+	if (!node->isLeader() && ( (do_auto_refine || do_sgd) && iter > 1) || (mymodel.nr_classes > 1 && allow_coarser_samplings) )
 	{
 		updateAngularSampling(node->rank == 1);
 	}
 
-	// The master needs to know about the updated parameters from updateAngularSampling
-	node->relion_MPI_Bcast(&has_fine_enough_angular_sampling, 1, MPI_INT, first_slave, MPI_COMM_WORLD);
-	node->relion_MPI_Bcast(&nr_iter_wo_resol_gain, 1, MPI_INT, first_slave, MPI_COMM_WORLD);
-	node->relion_MPI_Bcast(&nr_iter_wo_large_hidden_variable_changes, 1, MPI_INT, first_slave, MPI_COMM_WORLD);
-	node->relion_MPI_Bcast(&smallest_changes_optimal_classes, 1, MPI_INT, first_slave, MPI_COMM_WORLD);
-	node->relion_MPI_Bcast(&smallest_changes_optimal_offsets, 1, MY_MPI_DOUBLE, first_slave, MPI_COMM_WORLD);
-	node->relion_MPI_Bcast(&smallest_changes_optimal_orientations, 1, MY_MPI_DOUBLE, first_slave, MPI_COMM_WORLD);
+	// The leader needs to know about the updated parameters from updateAngularSampling
+	node->relion_MPI_Bcast(&has_fine_enough_angular_sampling, 1, MPI_INT, first_follower, MPI_COMM_WORLD);
+	node->relion_MPI_Bcast(&nr_iter_wo_resol_gain, 1, MPI_INT, first_follower, MPI_COMM_WORLD);
+	node->relion_MPI_Bcast(&nr_iter_wo_large_hidden_variable_changes, 1, MPI_INT, first_follower, MPI_COMM_WORLD);
+	node->relion_MPI_Bcast(&smallest_changes_optimal_classes, 1, MPI_INT, first_follower, MPI_COMM_WORLD);
+	node->relion_MPI_Bcast(&smallest_changes_optimal_offsets, 1, MY_MPI_DOUBLE, first_follower, MPI_COMM_WORLD);
+	node->relion_MPI_Bcast(&smallest_changes_optimal_orientations, 1, MY_MPI_DOUBLE, first_follower, MPI_COMM_WORLD);
 	if (mymodel.nr_bodies > 1)
 		for (int ibody=0; ibody < mymodel.nr_bodies; ibody++)
-			node->relion_MPI_Bcast(&mymodel.keep_fixed_bodies[ibody], 1, MPI_INT, first_slave, MPI_COMM_WORLD);
+			node->relion_MPI_Bcast(&mymodel.keep_fixed_bodies[ibody], 1, MPI_INT, first_follower, MPI_COMM_WORLD);
 
-	// Feb15,2016 - Shaoda - copy the following variables to the master
+	// Feb15,2016 - Shaoda - copy the following variables to the leader
 	if ( (do_helical_refine) && (!(helical_sigma_distance < 0.)) )
 	{
-		node->relion_MPI_Bcast(&sampling.healpix_order, 1, MPI_INT, first_slave, MPI_COMM_WORLD);
-		node->relion_MPI_Bcast(&mymodel.sigma2_rot, 1, MY_MPI_DOUBLE, first_slave, MPI_COMM_WORLD);
-		node->relion_MPI_Bcast(&mymodel.sigma2_tilt, 1, MY_MPI_DOUBLE, first_slave, MPI_COMM_WORLD);
-		node->relion_MPI_Bcast(&mymodel.sigma2_psi, 1, MY_MPI_DOUBLE, first_slave, MPI_COMM_WORLD);
-		node->relion_MPI_Bcast(&mymodel.sigma2_offset, 1, MY_MPI_DOUBLE, first_slave, MPI_COMM_WORLD);
-		node->relion_MPI_Bcast(&mymodel.orientational_prior_mode, 1, MPI_INT, first_slave, MPI_COMM_WORLD);
+		node->relion_MPI_Bcast(&sampling.healpix_order, 1, MPI_INT, first_follower, MPI_COMM_WORLD);
+		node->relion_MPI_Bcast(&mymodel.sigma2_rot, 1, MY_MPI_DOUBLE, first_follower, MPI_COMM_WORLD);
+		node->relion_MPI_Bcast(&mymodel.sigma2_tilt, 1, MY_MPI_DOUBLE, first_follower, MPI_COMM_WORLD);
+		node->relion_MPI_Bcast(&mymodel.sigma2_psi, 1, MY_MPI_DOUBLE, first_follower, MPI_COMM_WORLD);
+		node->relion_MPI_Bcast(&mymodel.sigma2_offset, 1, MY_MPI_DOUBLE, first_follower, MPI_COMM_WORLD);
+		node->relion_MPI_Bcast(&mymodel.orientational_prior_mode, 1, MPI_INT, first_follower, MPI_COMM_WORLD);
 	}
 
 	// For multi-body refinement: check if all bodies are fixed. If so, don't loop over all particles, but just return
@@ -923,11 +923,11 @@ void MlOptimiserMpi::expectation()
 			return;
 	}
 
-	// E. All nodes, except the master, check memory and precalculate AB-matrices for on-the-fly shifts
-	if (!node->isMaster())
+	// E. All nodes, except the leader, check memory and precalculate AB-matrices for on-the-fly shifts
+	if (!node->isLeader())
 	{
 		// Check whether everything fits into memory
-		int myverb = (node->rank == first_slave) ? 1 : 0;
+		int myverb = (node->rank == first_follower) ? 1 : 0;
 		MlOptimiser::expectationSetupCheckMemory(myverb);
 
 		// F. Precalculate AB-matrices for on-the-fly shifts
@@ -935,9 +935,9 @@ void MlOptimiserMpi::expectation()
 		if ( (do_shifts_onthefly) && (!((do_helical_refine) && (!ignore_helical_symmetry)))  && !(do_sgd && iter > 1))
 			precalculateABMatrices();
 	}
-	// Slave 1 sends has_converged to everyone else (in particular the master needs it!)
-	node->relion_MPI_Bcast(&has_converged, 1, MPI_INT, first_slave, MPI_COMM_WORLD);
-	node->relion_MPI_Bcast(&do_join_random_halves, 1, MPI_INT, first_slave, MPI_COMM_WORLD);
+	// Follower 1 sends has_converged to everyone else (in particular the leader needs it!)
+	node->relion_MPI_Bcast(&has_converged, 1, MPI_INT, first_follower, MPI_COMM_WORLD);
+	node->relion_MPI_Bcast(&do_join_random_halves, 1, MPI_INT, first_follower, MPI_COMM_WORLD);
 #ifdef TIMING
 	timer.toc(TIMING_EXP_3);
 	timer.tic(TIMING_EXP_4);
@@ -950,7 +950,7 @@ void MlOptimiserMpi::expectation()
 #ifdef TIMING
 	timer.toc(TIMING_EXP_4a);
 #endif
-	// Now perform real expectation step in parallel, use an on-demand master-slave system
+	// Now perform real expectation step in parallel, use an on-demand leader-follower system
 #define JOB_FIRST (first_last_nr_images(0))
 #define JOB_LAST  (first_last_nr_images(1))
 #define JOB_NIMG  (first_last_nr_images(2))
@@ -966,7 +966,7 @@ void MlOptimiserMpi::expectation()
 	std::vector<size_t> allocationSizes;
 	MPI_Barrier(MPI_COMM_WORLD);
 
-	if (do_gpu && ! node->isMaster())
+	if (do_gpu && ! node->isLeader())
 	{
 		for (int i = 0; i < cudaDevices.size(); i ++)
 		{
@@ -1035,7 +1035,7 @@ void MlOptimiserMpi::expectation()
 
 	MPI_Barrier(MPI_COMM_WORLD);
 
-	if (do_gpu && ! node->isMaster())
+	if (do_gpu && ! node->isLeader())
 	{
 		for (int i = 0; i < accDataBundles.size(); i ++)
 			((MlDeviceBundle*)accDataBundles[i])->setupTunableSizedObjects(allocationSizes[i]);
@@ -1045,7 +1045,7 @@ void MlOptimiserMpi::expectation()
 	/************************************************************************/
 	//CPU memory setup
 	MPI_Barrier(MPI_COMM_WORLD);   // Is this really necessary?
-	if (do_cpu  && ! node->isMaster())
+	if (do_cpu  && ! node->isLeader())
 	{
 		unsigned nr_classes = mymodel.PPref.size();
 		// Allocate Array of complex arrays for this class
@@ -1102,7 +1102,7 @@ void MlOptimiserMpi::expectation()
 	timer.toc(TIMING_EXP_4);
 #endif
 	long int my_nr_particles = (subset_size > 0) ? subset_size : mydata.numberOfParticles();
-	if (node->isMaster())
+	if (node->isLeader())
 	{
 #ifdef TIMING
 		timer.tic(TIMING_EXP_5);
@@ -1145,8 +1145,8 @@ void MlOptimiserMpi::expectation()
 				init_progress_bar(my_nr_particles);
 			}
 
-			// Master distributes all packages of SomeParticles
-			int nr_slaves_done = 0;
+			// Leader distributes all packages of SomeParticles
+			int nr_followers_done = 0;
 			int random_halfset = 0;
 			long int nr_particles_todo, nr_particles_done = 0;
 			long int nr_particles_done_halfset1 = 0;
@@ -1154,32 +1154,32 @@ void MlOptimiserMpi::expectation()
 			long int my_nr_particles_done = 0;
 
 
-			while (nr_slaves_done < node->size - 1)
+			while (nr_followers_done < node->size - 1)
 			{
 
 				pipeline_control_check_abort_job();
 
-				// Receive a job request from a slave
+				// Receive a job request from a follower
 				node->relion_MPI_Recv(MULTIDIM_ARRAY(first_last_nr_images), MULTIDIM_SIZE(first_last_nr_images), MPI_LONG, MPI_ANY_SOURCE, MPITAG_JOB_REQUEST, MPI_COMM_WORLD, status);
-				// Which slave sent this request?
-				int this_slave = status.MPI_SOURCE;
+				// Which follower sent this request?
+				int this_follower = status.MPI_SOURCE;
 
 //#define DEBUG_MPIEXP2
 #ifdef DEBUG_MPIEXP2
-				std::cerr << " MASTER RECEIVING from slave= " << this_slave<< " JOB_FIRST= " << JOB_FIRST << " JOB_LAST= " << JOB_LAST
+				std::cerr << " MASTER RECEIVING from follower= " << this_follower<< " JOB_FIRST= " << JOB_FIRST << " JOB_LAST= " << JOB_LAST
 						<< " JOB_NIMG= "<<JOB_NIMG<< " JOB_NPAR= "<<JOB_NPAR<< std::endl;
 #endif
-				// The first time a slave reports it only asks for input, but does not send output of a previous processing task. In that case JOB_NIMG==0
-				// Otherwise, the master needs to receive and handle the updated metadata from the slaves
+				// The first time a follower reports it only asks for input, but does not send output of a previous processing task. In that case JOB_NIMG==0
+				// Otherwise, the leader needs to receive and handle the updated metadata from the followers
 				if (JOB_NIMG > 0)
 				{
 					exp_metadata.resize(JOB_NIMG, METADATA_LINE_LENGTH_BEFORE_BODIES + (mymodel.nr_bodies) * METADATA_NR_BODY_PARAMS);
-					node->relion_MPI_Recv(MULTIDIM_ARRAY(exp_metadata), MULTIDIM_SIZE(exp_metadata), MY_MPI_DOUBLE, this_slave, MPITAG_METADATA, MPI_COMM_WORLD, status);
+					node->relion_MPI_Recv(MULTIDIM_ARRAY(exp_metadata), MULTIDIM_SIZE(exp_metadata), MY_MPI_DOUBLE, this_follower, MPITAG_METADATA, MPI_COMM_WORLD, status);
 
-					// The master monitors the changes in the optimal orientations and classes
+					// The leader monitors the changes in the optimal orientations and classes
 					monitorHiddenVariableChanges(JOB_FIRST, JOB_LAST);
 
-					// The master then updates the mydata.MDimg table
+					// The leader then updates the mydata.MDimg table
 					MlOptimiser::setMetaDataSubset(JOB_FIRST, JOB_LAST);
 					if (verb > 0 && nr_particles_done - prev_barstep> progress_bar_step_size)
 					{
@@ -1188,10 +1188,10 @@ void MlOptimiserMpi::expectation()
 					}
 				}
 
-				// See which random_halfset this slave belongs to, and keep track of the number of particles that have been processed already
+				// See which random_halfset this follower belongs to, and keep track of the number of particles that have been processed already
 				if (do_split_random_halves)
 				{
-					random_halfset = (this_slave % 2 == 1) ? 1 : 2;
+					random_halfset = (this_follower % 2 == 1) ? 1 : 2;
 					if (random_halfset == 1)
 					{
 						my_nr_particles_done = nr_particles_done_halfset1;
@@ -1237,8 +1237,8 @@ void MlOptimiserMpi::expectation()
 					exp_metadata.clear();
 					exp_imagedata.clear();
 
-					// No more particles, this slave is done now
-					nr_slaves_done++;
+					// No more particles, this follower is done now
+					nr_followers_done++;
 				}
 
 				//std::cerr << "subset= " << subset << " half-set= " << random_halfset
@@ -1246,32 +1246,32 @@ void MlOptimiserMpi::expectation()
 				//		<< " nr_particles_todo=" << nr_particles_todo << " JOB_FIRST= " << JOB_FIRST << " JOB_LAST= " << JOB_LAST << std::endl;
 
 #ifdef DEBUG_MPIEXP2
-				std::cerr << " MASTER SENDING to slave= " << this_slave<< " JOB_FIRST= " << JOB_FIRST << " JOB_LAST= " << JOB_LAST
+				std::cerr << " MASTER SENDING to follower= " << this_follower<< " JOB_FIRST= " << JOB_FIRST << " JOB_LAST= " << JOB_LAST
 								<< " JOB_NIMG= "<<JOB_NIMG<< " JOB_NPAR= "<<JOB_NPAR<< std::endl;
 #endif
-				node->relion_MPI_Send(MULTIDIM_ARRAY(first_last_nr_images), MULTIDIM_SIZE(first_last_nr_images), MPI_LONG, this_slave, MPITAG_JOB_REPLY, MPI_COMM_WORLD);
+				node->relion_MPI_Send(MULTIDIM_ARRAY(first_last_nr_images), MULTIDIM_SIZE(first_last_nr_images), MPI_LONG, this_follower, MPITAG_JOB_REPLY, MPI_COMM_WORLD);
 
-				//806 Master also sends the required metadata and imagedata for this job
+				//806 Leader also sends the required metadata and imagedata for this job
 				if (JOB_NIMG > 0)
 				{
-					node->relion_MPI_Send(MULTIDIM_ARRAY(exp_metadata), MULTIDIM_SIZE(exp_metadata), MY_MPI_DOUBLE, this_slave, MPITAG_METADATA, MPI_COMM_WORLD);
+					node->relion_MPI_Send(MULTIDIM_ARRAY(exp_metadata), MULTIDIM_SIZE(exp_metadata), MY_MPI_DOUBLE, this_follower, MPITAG_METADATA, MPI_COMM_WORLD);
 					if (do_parallel_disc_io)
 					{
-						node->relion_MPI_Send((void*)exp_fn_img.c_str(), JOB_LEN_FN_IMG, MPI_CHAR, this_slave, MPITAG_METADATA, MPI_COMM_WORLD);
-						// Send filenames of images to the slaves
+						node->relion_MPI_Send((void*)exp_fn_img.c_str(), JOB_LEN_FN_IMG, MPI_CHAR, this_follower, MPITAG_METADATA, MPI_COMM_WORLD);
+						// Send filenames of images to the followers
 						if (JOB_LEN_FN_CTF > 1)
-							node->relion_MPI_Send((void*)exp_fn_ctf.c_str(), JOB_LEN_FN_CTF, MPI_CHAR, this_slave, MPITAG_METADATA, MPI_COMM_WORLD);
+							node->relion_MPI_Send((void*)exp_fn_ctf.c_str(), JOB_LEN_FN_CTF, MPI_CHAR, this_follower, MPITAG_METADATA, MPI_COMM_WORLD);
 						if (JOB_LEN_FN_RECIMG > 1)
-							node->relion_MPI_Send((void*)exp_fn_recimg.c_str(), JOB_LEN_FN_RECIMG, MPI_CHAR, this_slave, MPITAG_METADATA, MPI_COMM_WORLD);
+							node->relion_MPI_Send((void*)exp_fn_recimg.c_str(), JOB_LEN_FN_RECIMG, MPI_CHAR, this_follower, MPITAG_METADATA, MPI_COMM_WORLD);
 					}
 					else
 					{
 						// new in 3.1: first send the image_size of these particles (as no longer necessarily the same as mymodel.ori_size...)
 						int my_image_size = mydata.getOpticsImageSize(mydata.getOpticsGroup(JOB_FIRST, 0));
-						node->relion_MPI_Send(&my_image_size, 1, MPI_INT, this_slave, MPITAG_IMAGE_SIZE, MPI_COMM_WORLD);
+						node->relion_MPI_Send(&my_image_size, 1, MPI_INT, this_follower, MPITAG_IMAGE_SIZE, MPI_COMM_WORLD);
 
-						// Send imagedata to the slaves
-						node->relion_MPI_Send(MULTIDIM_ARRAY(exp_imagedata), MULTIDIM_SIZE(exp_imagedata), MY_MPI_DOUBLE, this_slave, MPITAG_IMAGE, MPI_COMM_WORLD);
+						// Send imagedata to the followers
+						node->relion_MPI_Send(MULTIDIM_ARRAY(exp_imagedata), MULTIDIM_SIZE(exp_imagedata), MY_MPI_DOUBLE, this_follower, MPITAG_IMAGE, MPI_COMM_WORLD);
 					}
 				}
 
@@ -1293,29 +1293,29 @@ void MlOptimiserMpi::expectation()
 		}
 		catch (RelionError XE)
 		{
-			std::cerr << "master encountered error: " << XE;
+			std::cerr << "leader encountered error: " << XE;
 			MPI_Abort(MPI_COMM_WORLD, RELION_EXIT_FAILURE);
 		}
 #ifdef TIMING
 		timer.toc(TIMING_EXP_5);
 #endif
 	}
-	else  // if not Master
+	else  // if not Leader
 	{
 #ifdef TIMING
 		timer.tic(TIMING_EXP_6);
 #endif
 		try
 		{
-			if (halt_all_slaves_except_this > 0)
+			if (halt_all_followers_except_this > 0)
 			{
-				// Let all slaves except this one sleep forever
-				if (node->rank != halt_all_slaves_except_this)
+				// Let all followers except this one sleep forever
+				if (node->rank != halt_all_followers_except_this)
 					while (true)
 						sleep(1000);
 			}
 
-			// Slaves do the real work (The slave does not need to know to which random_halfset he belongs)
+			// Followers do the real work (The follower does not need to know to which random_halfset he belongs)
 			// Start off with an empty job request
 			JOB_FIRST = 0;
 			JOB_LAST = -1; // So that initial nr_particles (=JOB_LAST-JOB_FIRST+1) is zero!
@@ -1340,7 +1340,7 @@ void MlOptimiserMpi::expectation()
 				if (JOB_NIMG <= 0)
 				{
 #ifdef DEBUG
-					std::cerr <<" slave "<< node->rank << " has finished expectation.."<<std::endl;
+					std::cerr <<" follower "<< node->rank << " has finished expectation.."<<std::endl;
 #endif
 					exp_imagedata.clear();
 					exp_metadata.clear();
@@ -1351,7 +1351,7 @@ void MlOptimiserMpi::expectation()
 #ifdef TIMING
 					timer.tic(TIMING_MPISLAVEWAIT2);
 #endif
-					// Also receive the imagedata and the metadata for these images from the master
+					// Also receive the imagedata and the metadata for these images from the leader
 					exp_metadata.resize(JOB_NIMG, METADATA_LINE_LENGTH_BEFORE_BODIES + (mymodel.nr_bodies) * METADATA_NR_BODY_PARAMS);
 					node->relion_MPI_Recv(MULTIDIM_ARRAY(exp_metadata), MULTIDIM_SIZE(exp_metadata), MY_MPI_DOUBLE, 0, MPITAG_METADATA, MPI_COMM_WORLD, status);
 
@@ -1430,7 +1430,7 @@ void MlOptimiserMpi::expectation()
 					timer.tic(TIMING_MPISLAVEWAIT3);
 #endif
 
-					// Report to the master how many particles I have processed
+					// Report to the leader how many particles I have processed
 					node->relion_MPI_Send(MULTIDIM_ARRAY(first_last_nr_images), MULTIDIM_SIZE(first_last_nr_images), MPI_LONG, 0, MPITAG_JOB_REQUEST, MPI_COMM_WORLD);
 					// Also send the metadata belonging to those
 					node->relion_MPI_Send(MULTIDIM_ARRAY(exp_metadata), MULTIDIM_SIZE(exp_metadata), MY_MPI_DOUBLE, 0, MPITAG_METADATA, MPI_COMM_WORLD);
@@ -1567,13 +1567,13 @@ void MlOptimiserMpi::expectation()
 		}
 		catch (RelionError XE)
 		{
-			std::cerr << "slave "<< node->rank << " encountered error: " << XE;
+			std::cerr << "follower "<< node->rank << " encountered error: " << XE;
 			MPI_Abort(MPI_COMM_WORLD, RELION_EXIT_FAILURE);
 		}
 #ifdef TIMING
 		timer.toc(TIMING_EXP_6);
 #endif
-	}  // Slave node
+	}  // Follower node
 
 #ifdef  MKLFFT
 	// Allow parallel FFTW execution to continue now that we are outside the parallel
@@ -1600,8 +1600,8 @@ void MlOptimiserMpi::expectation()
 	// Wait until expected angular errors have been calculated
 	MPI_Barrier(MPI_COMM_WORLD);
 
-	// All slaves reset the size of their projector to zero to save memory
-	if (!node->isMaster())
+	// All followers reset the size of their projector to zero to save memory
+	if (!node->isLeader())
 	{
 		for (int iclass = 0; iclass < mymodel.nr_classes; iclass++)
 			mymodel.PPref[iclass].initialiseData(0);
@@ -1624,19 +1624,19 @@ void MlOptimiserMpi::combineAllWeightedSumsViaFile()
 
 	int nr_halfsets = (do_split_random_halves) ? 2 : 1;
 
-	// Only need to combine if there are more than one slaves per subset!
+	// Only need to combine if there are more than one followers per subset!
 	if ((node->size - 1)/nr_halfsets > 1)
 	{
-		// A. First all slaves pack up their wsum_model (this is done simultaneously)
-		if (!node->isMaster())
+		// A. First all followers pack up their wsum_model (this is done simultaneously)
+		if (!node->isLeader())
 		{
 			wsum_model.pack(Mpack); // use negative piece and nr_pieces to only make a single Mpack, i.e. do not split into multiple pieces
 		}
 
-		// B. All slaves write their Mpack to disc. Do this SEQUENTIALLY to prevent heavy load on disc I/O
-		for (int this_slave = 1; this_slave < node->size; this_slave++ )
+		// B. All followers write their Mpack to disc. Do this SEQUENTIALLY to prevent heavy load on disc I/O
+		for (int this_follower = 1; this_follower < node->size; this_follower++ )
 		{
-			if (this_slave == node->rank)
+			if (this_follower == node->rank)
 			{
 				fn_pack.compose(fn_out+"_rank", node->rank, "tmp");
 				Mpack.writeBinary(fn_pack);
@@ -1647,43 +1647,43 @@ void MlOptimiserMpi::combineAllWeightedSumsViaFile()
 		}
 		MPI_Barrier(MPI_COMM_WORLD);
 
-		// C. First slave of each subset reads all other slaves' Mpack; sum; and write sum to disc
+		// C. First follower of each subset reads all other followers' Mpack; sum; and write sum to disc
 		// Again, do this SEQUENTIALLY to prevent heavy load on disc I/O
-		for (int first_slave = 1; first_slave <= nr_halfsets; first_slave++)
+		for (int first_follower = 1; first_follower <= nr_halfsets; first_follower++)
 		{
-			if (node->rank == first_slave)
+			if (node->rank == first_follower)
 			{
-				for (int other_slave = first_slave + nr_halfsets; other_slave < node->size; other_slave+= nr_halfsets )
+				for (int other_follower = first_follower + nr_halfsets; other_follower < node->size; other_follower+= nr_halfsets )
 				{
-					fn_pack.compose(fn_out+"_rank", other_slave, "tmp");
+					fn_pack.compose(fn_out+"_rank", other_follower, "tmp");
 					Mpack.readBinaryAndSum(fn_pack);
-					//std::cerr << "Slave "<<node->rank<<" has read "<<fn_pack<< " sum= "<<Mpack.sum() << std::endl;
+					//std::cerr << "Follower "<<node->rank<<" has read "<<fn_pack<< " sum= "<<Mpack.sum() << std::endl;
 				}
 				// After adding all Mpacks together: write the sum to disc
 				fn_pack.compose(fn_out+"_rank", node->rank, "tmp");
 				Mpack.writeBinary(fn_pack);
-				//std::cerr << "Slave "<<node->rank<<" is writing total SUM in "<<fn_pack << std::endl;
+				//std::cerr << "Follower "<<node->rank<<" is writing total SUM in "<<fn_pack << std::endl;
 			}
 			if (!do_parallel_disc_io)
 				MPI_Barrier(MPI_COMM_WORLD);
 		}
 		MPI_Barrier(MPI_COMM_WORLD);
 
-		// D. All other slaves read the summed Mpack from their first_slave
+		// D. All other followers read the summed Mpack from their first_follower
 		// Again, do this SEQUENTIALLY to prevent heavy load on disc I/O
-		for (int this_slave = nr_halfsets + 1; this_slave < node->size; this_slave++ )
+		for (int this_follower = nr_halfsets + 1; this_follower < node->size; this_follower++ )
 		{
-			if (this_slave == node->rank)
+			if (this_follower == node->rank)
 			{
-				// Find out who is the first slave in this subset
-				int first_slave;
+				// Find out who is the first follower in this subset
+				int first_follower;
 				if (!do_split_random_halves)
-					first_slave = 1;
+					first_follower = 1;
 				else
-					first_slave = (this_slave % 2 == 1) ? 1 : 2;
+					first_follower = (this_follower % 2 == 1) ? 1 : 2;
 
 				// Read the corresponding Mpack (which now contains the sum of all Mpacks)
-				fn_pack.compose(fn_out+"_rank", first_slave, "tmp");
+				fn_pack.compose(fn_out+"_rank", first_follower, "tmp");
 				Mpack.readBinary(fn_pack);
 				//std::cerr << "Rank "<< node->rank <<" has read: "<<fn_pack << " sum= "<<Mpack.sum()<< std::endl;
 			}
@@ -1692,11 +1692,11 @@ void MlOptimiserMpi::combineAllWeightedSumsViaFile()
 		}
 		MPI_Barrier(MPI_COMM_WORLD);
 
-		// E. All slaves delete their own temporary file
+		// E. All followers delete their own temporary file
 		// Again, do this SEQUENTIALLY to prevent heavy load on disc I/O
-		for (int this_slave = 1; this_slave < node->size; this_slave++ )
+		for (int this_follower = 1; this_follower < node->size; this_follower++ )
 		{
-			if (this_slave == node->rank)
+			if (this_follower == node->rank)
 			{
 				fn_pack.compose(fn_out+"_rank", node->rank, "tmp");
 				remove((fn_pack).c_str());
@@ -1706,8 +1706,8 @@ void MlOptimiserMpi::combineAllWeightedSumsViaFile()
 				MPI_Barrier(MPI_COMM_WORLD);
 		}
 
-		// F. Finally all slaves unpack Msum into their wsum_model (do this simultaneously)
-		if (!node->isMaster())
+		// F. Finally all followers unpack Msum into their wsum_model (do this simultaneously)
+		if (!node->isLeader())
 			wsum_model.unpack(Mpack);
 
 	} // end if ((node->size - 1)/nr_halfsets > 1)
@@ -1727,14 +1727,14 @@ void MlOptimiserMpi::combineAllWeightedSums()
 	MultidimArray<RFLOAT> Mpack, Msum;
 	MPI_Status status;
 
-	// First slave manually sums over all other slaves of it's subset
-	// And then sends results back to all those slaves
+	// First follower manually sums over all other followers of it's subset
+	// And then sends results back to all those followers
 	// When splitting the data into two random halves, perform two passes: one for each subset
 	int nr_halfsets = (do_split_random_halves) ? 2 : 1;
 #ifdef DEBUG
 	std::cerr << " starting combineAllWeightedSums..." << std::endl;
 #endif
-	// Only combine weighted sums if there are more than one slaves per subset!
+	// Only combine weighted sums if there are more than one followers per subset!
 	if ((node->size - 1)/nr_halfsets > 1)
 	{
 		// Loop over possibly multiple instances of Mpack of maximum size
@@ -1745,11 +1745,11 @@ void MlOptimiserMpi::combineAllWeightedSums()
 			// All nodes except those who will reset nr_pieces piece will pass while loop in next pass
 			nr_pieces = 0;
 
-			// First all slaves pack up their wsum_model
-			if (!node->isMaster())
+			// First all followers pack up their wsum_model
+			if (!node->isLeader())
 			{
 				wsum_model.pack(Mpack, piece, nr_pieces);
-				// The first slave(s) set Msum equal to Mpack, the others initialise to zero
+				// The first follower(s) set Msum equal to Mpack, the others initialise to zero
 				if (node->rank <= nr_halfsets)
 					Msum = Mpack;
 				else
@@ -1757,36 +1757,36 @@ void MlOptimiserMpi::combineAllWeightedSums()
 			}
 
 
-			// Loop through all slaves: each slave sends its Msum to the next slave for its subset.
-			// Each next slave sums its own Mpack to the received Msum and sends it on to the next slave
-			for (int this_slave = 1; this_slave < node->size; this_slave++ )
+			// Loop through all followers: each follower sends its Msum to the next follower for its subset.
+			// Each next follower sums its own Mpack to the received Msum and sends it on to the next follower
+			for (int this_follower = 1; this_follower < node->size; this_follower++ )
 			{
-				// Find out who is the first slave in this subset
-				int first_slave;
+				// Find out who is the first follower in this subset
+				int first_follower;
 				if (!do_split_random_halves)
-					first_slave = 1;
+					first_follower = 1;
 				else
-					first_slave = (this_slave % 2 == 1) ? 1 : 2;
+					first_follower = (this_follower % 2 == 1) ? 1 : 2;
 
-				// Find out who is the next slave in this subset
-				int other_slave = this_slave + nr_halfsets;
+				// Find out who is the next follower in this subset
+				int other_follower = this_follower + nr_halfsets;
 
-				if (other_slave < node->size)
+				if (other_follower < node->size)
 				{
-					if (node->rank == this_slave)
+					if (node->rank == this_follower)
 					{
 #ifdef DEBUG
 						std::cerr << " AA SEND node->rank= " << node->rank << " MULTIDIM_SIZE(Msum)= "<< MULTIDIM_SIZE(Msum)
-								<< " this_slave= " << this_slave << " other_slave= "<<other_slave << std::endl;
+								<< " this_follower= " << this_follower << " other_follower= "<<other_follower << std::endl;
 #endif
-						node->relion_MPI_Send(MULTIDIM_ARRAY(Msum), MULTIDIM_SIZE(Msum), MY_MPI_DOUBLE, other_slave, MPITAG_PACK, MPI_COMM_WORLD);
+						node->relion_MPI_Send(MULTIDIM_ARRAY(Msum), MULTIDIM_SIZE(Msum), MY_MPI_DOUBLE, other_follower, MPITAG_PACK, MPI_COMM_WORLD);
 					}
-					else if (node->rank == other_slave)
+					else if (node->rank == other_follower)
 					{
-						node->relion_MPI_Recv(MULTIDIM_ARRAY(Msum), MULTIDIM_SIZE(Msum), MY_MPI_DOUBLE, this_slave, MPITAG_PACK, MPI_COMM_WORLD, status);
+						node->relion_MPI_Recv(MULTIDIM_ARRAY(Msum), MULTIDIM_SIZE(Msum), MY_MPI_DOUBLE, this_follower, MPITAG_PACK, MPI_COMM_WORLD, status);
 #ifdef DEBUG
 						std::cerr << " AA RECV node->rank= " << node->rank  << " MULTIDIM_SIZE(Msum)= "<< MULTIDIM_SIZE(Msum)
-								<< " this_slave= " << this_slave << " other_slave= "<<other_slave << std::endl;
+								<< " this_follower= " << this_follower << " other_follower= "<<other_follower << std::endl;
 #endif
 						// Add my own Mpack to send onwards in the next step
 						Msum += Mpack;
@@ -1794,57 +1794,57 @@ void MlOptimiserMpi::combineAllWeightedSums()
 				}
 				else
 				{
-					// Now this_slave has reached the last slave, which passes the final Msum to the first one (i.e. first_slave)
-					if (node->rank == this_slave)
+					// Now this_follower has reached the last follower, which passes the final Msum to the first one (i.e. first_follower)
+					if (node->rank == this_follower)
 					{
 #ifdef DEBUG
 						std::cerr << " BB SEND node->rank= " << node->rank  << " MULTIDIM_SIZE(Msum)= "<< MULTIDIM_SIZE(Msum)
-								<< " this_slave= " << this_slave << " first_slave= "<<first_slave << std::endl;
+								<< " this_follower= " << this_follower << " first_follower= "<<first_follower << std::endl;
 #endif
-						node->relion_MPI_Send(MULTIDIM_ARRAY(Msum), MULTIDIM_SIZE(Msum), MY_MPI_DOUBLE, first_slave, MPITAG_PACK, MPI_COMM_WORLD);
+						node->relion_MPI_Send(MULTIDIM_ARRAY(Msum), MULTIDIM_SIZE(Msum), MY_MPI_DOUBLE, first_follower, MPITAG_PACK, MPI_COMM_WORLD);
 					}
-					else if (node->rank == first_slave)
+					else if (node->rank == first_follower)
 					{
-						node->relion_MPI_Recv(MULTIDIM_ARRAY(Msum), MULTIDIM_SIZE(Msum), MY_MPI_DOUBLE, this_slave, MPITAG_PACK, MPI_COMM_WORLD, status);
+						node->relion_MPI_Recv(MULTIDIM_ARRAY(Msum), MULTIDIM_SIZE(Msum), MY_MPI_DOUBLE, this_follower, MPITAG_PACK, MPI_COMM_WORLD, status);
 #ifdef DEBUG
 						std::cerr << " BB RECV node->rank= " << node->rank  << " MULTIDIM_SIZE(Msum)= "<< MULTIDIM_SIZE(Msum)
-								<< " this_slave= " << this_slave << " first_slave= "<<first_slave << std::endl;
+								<< " this_follower= " << this_follower << " first_follower= "<<first_follower << std::endl;
 #endif
 					}
 				}
-			} // end for this_slave
+			} // end for this_follower
 
-			// Now loop through all slaves again to pass around the Msum
-			for (int this_slave = 1; this_slave < node->size; this_slave++ )
+			// Now loop through all followers again to pass around the Msum
+			for (int this_follower = 1; this_follower < node->size; this_follower++ )
 			{
-				// Find out who is the next slave in this subset
-				int other_slave = this_slave + nr_halfsets;
+				// Find out who is the next follower in this subset
+				int other_follower = this_follower + nr_halfsets;
 
-				// Do not send to the last slave, because it already had its Msum from the cycle above, therefore subtract nr_halfsets from node->size
-				if (other_slave < node->size - nr_halfsets)
+				// Do not send to the last follower, because it already had its Msum from the cycle above, therefore subtract nr_halfsets from node->size
+				if (other_follower < node->size - nr_halfsets)
 				{
-					if (node->rank == this_slave)
+					if (node->rank == this_follower)
 					{
 #ifdef DEBUG
 						std::cerr << " CC SEND node->rank= " << node->rank << " MULTIDIM_SIZE(Msum)= "<< MULTIDIM_SIZE(Msum)
-								<< " this_slave= " << this_slave << " other_slave= "<<other_slave << std::endl;
+								<< " this_follower= " << this_follower << " other_follower= "<<other_follower << std::endl;
 #endif
-						node->relion_MPI_Send(MULTIDIM_ARRAY(Msum), MULTIDIM_SIZE(Msum), MY_MPI_DOUBLE, other_slave, MPITAG_PACK, MPI_COMM_WORLD);
+						node->relion_MPI_Send(MULTIDIM_ARRAY(Msum), MULTIDIM_SIZE(Msum), MY_MPI_DOUBLE, other_follower, MPITAG_PACK, MPI_COMM_WORLD);
 					}
-					else if (node->rank == other_slave)
+					else if (node->rank == other_follower)
 					{
-						node->relion_MPI_Recv(MULTIDIM_ARRAY(Msum), MULTIDIM_SIZE(Msum), MY_MPI_DOUBLE, this_slave, MPITAG_PACK, MPI_COMM_WORLD, status);
+						node->relion_MPI_Recv(MULTIDIM_ARRAY(Msum), MULTIDIM_SIZE(Msum), MY_MPI_DOUBLE, this_follower, MPITAG_PACK, MPI_COMM_WORLD, status);
 #ifdef DEBUG
 						std::cerr << " CC RECV node->rank= " << node->rank << " MULTIDIM_SIZE(Msum)= "<< MULTIDIM_SIZE(Msum)
-								<< " this_slave= " << this_slave << " other_slave= "<<other_slave << std::endl;
+								<< " this_follower= " << this_follower << " other_follower= "<<other_follower << std::endl;
 #endif
 					}
 				}
-			} // end for this_slave
+			} // end for this_follower
 
 
-			// Finally all slaves unpack Msum into their wsum_model
-			if (!node->isMaster())
+			// Finally all followers unpack Msum into their wsum_model
+			if (!node->isLeader())
 			{
 				// Subtract 1 from piece because it was incremented already...
 				wsum_model.unpack(Msum, piece - 1);
@@ -1863,7 +1863,7 @@ void MlOptimiserMpi::combineAllWeightedSums()
 
 void MlOptimiserMpi::combineWeightedSumsTwoRandomHalvesViaFile()
 {
-	// Just sum the weighted halves from slave 1 and slave 2 and Bcast to everyone else
+	// Just sum the weighted halves from follower 1 and follower 2 and Bcast to everyone else
 	if (!do_split_random_halves)
 		REPORT_ERROR("MlOptimiserMpi::combineWeightedSumsTwoRandomHalvesViaFile BUG: you cannot combineWeightedSumsTwoRandomHalves if you have not split random halves");
 
@@ -1871,8 +1871,8 @@ void MlOptimiserMpi::combineWeightedSumsTwoRandomHalvesViaFile()
 	FileName fn_pack = fn_out + ".tmp";
 
 	// Everyone packs up his wsum_model (simultaneously)
-	// The slaves from 3 and onwards also need this in order to have the correct Mpack size to be able to read in the summed Mpack
-	if (!node->isMaster())
+	// The followers from 3 and onwards also need this in order to have the correct Mpack size to be able to read in the summed Mpack
+	if (!node->isLeader())
 		wsum_model.pack(Mpack);
 
 	// Rank 2 writes it Mpack to file
@@ -1892,11 +1892,11 @@ void MlOptimiserMpi::combineWeightedSumsTwoRandomHalvesViaFile()
 		Mpack.writeBinary(fn_pack);
 	}
 
-	// Now all slaves read the sum and unpack
+	// Now all followers read the sum and unpack
 	// Do this sequentially in order not to have very heavy disc I/O
-	for (int this_slave = 2; this_slave < node->size; this_slave++)
+	for (int this_follower = 2; this_follower < node->size; this_follower++)
 	{
-		if (node->rank == this_slave)
+		if (node->rank == this_follower)
 			Mpack.readBinary(fn_pack);
 		if (!do_parallel_disc_io)
 			MPI_Barrier(MPI_COMM_WORLD);
@@ -1909,14 +1909,14 @@ void MlOptimiserMpi::combineWeightedSumsTwoRandomHalvesViaFile()
 	if (node->rank == 1)
 		remove(fn_pack.c_str());
 
-	// Then everyone except the master unpacks
-	if (!node->isMaster())
+	// Then everyone except the leader unpacks
+	if (!node->isLeader())
 		wsum_model.unpack(Mpack);
 }
 
 void MlOptimiserMpi::combineWeightedSumsTwoRandomHalves()
 {
-	// Just sum the weighted halves from slave 1 and slave 2 and Bcast to everyone else
+	// Just sum the weighted halves from follower 1 and follower 2 and Bcast to everyone else
 	if (!do_split_random_halves)
 		REPORT_ERROR("MlOptimiserMpi::combineWeightedSumsTwoRandomHalves BUG: you cannot combineWeightedSumsTwoRandomHalves if you have not split random halves");
 
@@ -1951,7 +1951,7 @@ void MlOptimiserMpi::combineWeightedSumsTwoRandomHalves()
 		}
 	}
 
-	// Now slave 1 has the sum of the two halves
+	// Now follower 1 has the sum of the two halves
 	MPI_Barrier(MPI_COMM_WORLD);
 
 	// Bcast to everyone
@@ -1963,8 +1963,8 @@ void MlOptimiserMpi::combineWeightedSumsTwoRandomHalves()
 		// All nodes except those who will reset nr_pieces will pass while next time
 		nr_pieces = 0;
 
-		// The master does not have a wsum_model!
-		if (!node->isMaster())
+		// The leader does not have a wsum_model!
+		if (!node->isLeader())
 		{
 			// Let's have everyone repack their Mpack, so we know the size etc
 			wsum_model.pack(Mpack, piece, nr_pieces);
@@ -1972,8 +1972,8 @@ void MlOptimiserMpi::combineWeightedSumsTwoRandomHalves()
 			// rank one sends Mpack to everyone else
 			if (node->rank == 1)
 			{
-				for (int other_slave = 2; other_slave < node->size; other_slave++)
-					node->relion_MPI_Send(MULTIDIM_ARRAY(Mpack), MULTIDIM_SIZE(Mpack), MY_MPI_DOUBLE, other_slave, MPITAG_PACK, MPI_COMM_WORLD);
+				for (int other_follower = 2; other_follower < node->size; other_follower++)
+					node->relion_MPI_Send(MULTIDIM_ARRAY(Mpack), MULTIDIM_SIZE(Mpack), MY_MPI_DOUBLE, other_follower, MPITAG_PACK, MPI_COMM_WORLD);
 			}
 			else
 			{
@@ -2074,7 +2074,7 @@ void MlOptimiserMpi::maximization()
 									mymodel.data_vs_prior_class[ith_recons],
 									(do_join_random_halves || do_always_join_random_halves),
 									mymodel.tau2_fudge_factor,
-									node->rank==1); // only first slaves is verbose
+									node->rank==1); // only first followers is verbose
 						}
 						else
 						{
@@ -2372,8 +2372,8 @@ void MlOptimiserMpi::maximization()
 				if (!do_join_random_halves)
 				{
 					MPI_Status status;
-					// Make sure I am sending from the rank where the reconstruction was done (see above) to all other slaves of this subset
-					// Loop twice through this, as each class was reconstructed by two different slaves!!
+					// Make sure I am sending from the rank where the reconstruction was done (see above) to all other followers of this subset
+					// Loop twice through this, as each class was reconstructed by two different followers!!
 					int nr_halfsets = 2;
 					for (int ihalfset = 1; ihalfset <= nr_halfsets; ihalfset++)
 					{
@@ -2412,7 +2412,7 @@ void MlOptimiserMpi::maximization()
 					// No one should continue until we're all here
 					MPI_Barrier(MPI_COMM_WORLD);
 
-					// Now all slaves have all relevant reconstructions to continue
+					// Now all followers have all relevant reconstructions to continue
 				}
 			}
 			else
@@ -2472,23 +2472,23 @@ void MlOptimiserMpi::maximization()
 		timer.toc(TIMING_RECONS);
 #endif
 
-	if (node->isMaster())
+	if (node->isLeader())
 	{
 		RCTIC(timer,RCT_4);
-		// The master also updates the changes in hidden variables
+		// The leader also updates the changes in hidden variables
 		updateOverallChangesInHiddenVariables();
 		RCTOC(timer,RCT_4);
 	}
 	else
 	{
 		// Now do the maximisation of all other parameters (and calculate the tau2_class-spectra of the reconstructions
-		// The lazy master never does this: it only handles metadata and does not have the weighted sums
+		// The lazy leader never does this: it only handles metadata and does not have the weighted sums
 		RCTIC(timer,RCT_3);
 		maximizationOtherParameters();
 		RCTOC(timer,RCT_3);
 	}
 
-	// The master broadcasts the changes in hidden variables to all other nodes
+	// The leader broadcasts the changes in hidden variables to all other nodes
 	node->relion_MPI_Bcast(&current_changes_optimal_classes, 1, MY_MPI_DOUBLE, 0, MPI_COMM_WORLD);
 	node->relion_MPI_Bcast(&current_changes_optimal_orientations, 1, MY_MPI_DOUBLE, 0, MPI_COMM_WORLD);
 	node->relion_MPI_Bcast(&current_changes_optimal_offsets, 1, MY_MPI_DOUBLE, 0, MPI_COMM_WORLD);
@@ -2573,17 +2573,17 @@ void MlOptimiserMpi::joinTwoHalvesAtLowResolution()
 				std::cerr << " RANK2A: node->rank= " << node->rank << std::endl;
 				std::cerr << "AAArank=2 lowresdata: "; lowres_data.printShape();
 #endif
-				// The second slave sends its lowres_data and lowres_weight to the first slave
+				// The second follower sends its lowres_data and lowres_weight to the first follower
 				node->relion_MPI_Send(MULTIDIM_ARRAY(lowres_data), 2*MULTIDIM_SIZE(lowres_data), MY_MPI_DOUBLE, reconstruct_rank1, MPITAG_IMAGE, MPI_COMM_WORLD);
 				node->relion_MPI_Send(MULTIDIM_ARRAY(lowres_weight), MULTIDIM_SIZE(lowres_weight), MY_MPI_DOUBLE, reconstruct_rank1, MPITAG_RFLOAT, MPI_COMM_WORLD);
 
-				// Now the first slave is calculating the average....
+				// Now the first follower is calculating the average....
 #ifdef DEBUG
 				std::cerr << " RANK2B: node->rank= " << node->rank << std::endl;
 				std::cerr << "BBBrank=2 lowresdata: "; lowres_data.printShape();
 #endif
 
-				// Then the second slave receives the average back from the first slave
+				// Then the second follower receives the average back from the first follower
 				node->relion_MPI_Recv(MULTIDIM_ARRAY(lowres_data), 2*MULTIDIM_SIZE(lowres_data), MY_MPI_DOUBLE, reconstruct_rank1, MPITAG_IMAGE, MPI_COMM_WORLD, status);
 				node->relion_MPI_Recv(MULTIDIM_ARRAY(lowres_weight), MULTIDIM_SIZE(lowres_weight), MY_MPI_DOUBLE, reconstruct_rank1, MPITAG_RFLOAT, MPI_COMM_WORLD, status);
 
@@ -2607,11 +2607,11 @@ void MlOptimiserMpi::joinTwoHalvesAtLowResolution()
 				std::cerr << "AAArank=1 lowresdata_half2: "; lowres_data_half2.printShape();
 				std::cerr << "RANK1B: node->rank= " << node->rank << std::endl;
 #endif
-				// The first slave receives the average from the second slave
+				// The first follower receives the average from the second follower
 				node->relion_MPI_Recv(MULTIDIM_ARRAY(lowres_data_half2), 2*MULTIDIM_SIZE(lowres_data_half2), MY_MPI_DOUBLE, reconstruct_rank2, MPITAG_IMAGE, MPI_COMM_WORLD, status);
 				node->relion_MPI_Recv(MULTIDIM_ARRAY(lowres_weight_half2), MULTIDIM_SIZE(lowres_weight_half2), MY_MPI_DOUBLE, reconstruct_rank2, MPITAG_RFLOAT, MPI_COMM_WORLD, status);
 
-				// The first slave calculates the average of the two lowres_data and lowres_weight arrays
+				// The first follower calculates the average of the two lowres_data and lowres_weight arrays
 #ifdef DEBUG
 				std::cerr << "BBBrank=1 lowresdata: "; lowres_data.printShape();
 				std::cerr << "BBBrank=1 lowresdata_half2: "; lowres_data_half2.printShape();
@@ -2624,13 +2624,13 @@ void MlOptimiserMpi::joinTwoHalvesAtLowResolution()
 					DIRECT_MULTIDIM_ELEM(lowres_weight, n) /= 2.;
 				}
 
-				// The first slave sends the average lowres_data and lowres_weight also back to the second slave
+				// The first follower sends the average lowres_data and lowres_weight also back to the second follower
 				node->relion_MPI_Send(MULTIDIM_ARRAY(lowres_data), 2*MULTIDIM_SIZE(lowres_data), MY_MPI_DOUBLE, reconstruct_rank2, MPITAG_IMAGE, MPI_COMM_WORLD);
 				node->relion_MPI_Send(MULTIDIM_ARRAY(lowres_weight), MULTIDIM_SIZE(lowres_weight), MY_MPI_DOUBLE, reconstruct_rank2, MPITAG_RFLOAT, MPI_COMM_WORLD);
 
 			}
 
-			// Now that both slaves have the average lowres arrays, set them back into the backprojector
+			// Now that both followers have the average lowres arrays, set them back into the backprojector
 			wsum_model.BPref[ibody].setLowResDataAndWeight(lowres_data, lowres_weight, lowres_r_max);
 		}
 	}
@@ -2690,7 +2690,7 @@ void MlOptimiserMpi::reconstructUnregularisedMapAndCalculateSolventCorrectedFSC(
 			Iunreg.write(fn_root+"_unfil.mrc");
 		}
 
-		// reconstruct_rank1 also sends the current_size to the master, so that it knows where to cut the FSC to zero
+		// reconstruct_rank1 also sends the current_size to the leader, so that it knows where to cut the FSC to zero
 		MPI_Status status;
 		if (node->rank == reconstruct_rank1)
 			node->relion_MPI_Send(&mymodel.current_size, 1, MPI_INT, 0, MPITAG_INT, MPI_COMM_WORLD);
@@ -2699,7 +2699,7 @@ void MlOptimiserMpi::reconstructUnregularisedMapAndCalculateSolventCorrectedFSC(
 
 		MPI_Barrier(MPI_COMM_WORLD);
 
-		if (node->rank == 0) // Let's do this on the master (hopefully it has more memory)
+		if (node->rank == 0) // Let's do this on the leader (hopefully it has more memory)
 		{
 			if (mymodel.nr_bodies > 1)
 				std::cout << " Calculating solvent-corrected gold-standard FSC for " << ibody+1 << "th body ..."<< std::endl;
@@ -2815,7 +2815,7 @@ void MlOptimiserMpi::reconstructUnregularisedMapAndCalculateSolventCorrectedFSC(
 
 		}
 
-		// Now the master sends the fsc curve to everyone else
+		// Now the leader sends the fsc curve to everyone else
 		node->relion_MPI_Bcast(MULTIDIM_ARRAY(mymodel.fsc_halves_class[ibody]), MULTIDIM_SIZE(mymodel.fsc_halves_class[ibody]), MY_MPI_DOUBLE, 0, MPI_COMM_WORLD);
 
 	} // end loop over all bodies
@@ -2972,7 +2972,7 @@ void MlOptimiserMpi::compareTwoHalves()
 		if (mymodel.nr_bodies > 1 && mymodel.keep_fixed_bodies[ibody] > 0)
 			continue;
 
-		// The first two slaves calculate the sum of the downsampled average of all bodies
+		// The first two followers calculate the sum of the downsampled average of all bodies
 		if (node->rank == 1 || node->rank == 2)
 		{
 			MultidimArray<Complex > avg1;
@@ -3002,7 +3002,7 @@ void MlOptimiserMpi::compareTwoHalves()
 
 			if (node->rank == 2)
 			{
-				// The second slave sends its average to the first slave
+				// The second follower sends its average to the first follower
 				node->relion_MPI_Send(MULTIDIM_ARRAY(avg1), 2*MULTIDIM_SIZE(avg1), MY_MPI_DOUBLE, 1, MPITAG_IMAGE, MPI_COMM_WORLD);
 			}
 			else if (node->rank == 1)
@@ -3012,7 +3012,7 @@ void MlOptimiserMpi::compareTwoHalves()
 					std::cout << " Calculating gold-standard FSC for " << ibody+1 << "th body ..."<< std::endl;
 				else
 					std::cout << " Calculating gold-standard FSC ..."<< std::endl;
-				// The first slave receives the average from the second slave and calculates the FSC between them
+				// The first follower receives the average from the second follower and calculates the FSC between them
 				MPI_Status status;
 				MultidimArray<Complex > avg2;
 				avg2.resize(avg1);
@@ -3022,7 +3022,7 @@ void MlOptimiserMpi::compareTwoHalves()
 
 		}
 
-		// Now slave 1 sends the fsc curve to everyone else
+		// Now follower 1 sends the fsc curve to everyone else
 		node->relion_MPI_Bcast(MULTIDIM_ARRAY(mymodel.fsc_halves_class[ibody]), MULTIDIM_SIZE(mymodel.fsc_halves_class[ibody]), MY_MPI_DOUBLE, 1, MPI_COMM_WORLD);
 
 	} // end loop over bodies
@@ -3039,10 +3039,10 @@ void MlOptimiserMpi::iterate()
 	TIMING_MPIWAIT= timer.setNew("mpiWaitEndOfExpectation");
 	TIMING_MPICOMBINEDISC= timer.setNew("mpiCombineThroughDisc");
 	TIMING_MPICOMBINENETW= timer.setNew("mpiCombineThroughNetwork");
-	TIMING_MPISLAVEWORK= timer.setNew("mpiSlaveWorking");
-	TIMING_MPISLAVEWAIT1= timer.setNew("mpiSlaveWaiting1");
-	TIMING_MPISLAVEWAIT2= timer.setNew("mpiSlaveWaiting2");
-	TIMING_MPISLAVEWAIT3= timer.setNew("mpiSlaveWaiting3");
+	TIMING_MPISLAVEWORK= timer.setNew("mpiFollowerWorking");
+	TIMING_MPISLAVEWAIT1= timer.setNew("mpiFollowerWaiting1");
+	TIMING_MPISLAVEWAIT2= timer.setNew("mpiFollowerWaiting2");
+	TIMING_MPISLAVEWAIT3= timer.setNew("mpiFollowerWaiting3");
 #endif
 
 	// Launch threads etc.
@@ -3058,7 +3058,7 @@ void MlOptimiserMpi::iterate()
 #endif
 
 		// Update subset_size
-		updateSubsetSize(node->isMaster());
+		updateSubsetSize(node->isLeader());
 
 		// Randomly take different subset of the particles each time we do a new "iteration" in SGD
 		if (random_seed > 0)
@@ -3073,7 +3073,7 @@ void MlOptimiserMpi::iterate()
 		// Nobody can start the next iteration until everyone has finished
 		MPI_Barrier(MPI_COMM_WORLD);
 
-		// Only first slave checks for convergence and prints stats to the stdout
+		// Only first follower checks for convergence and prints stats to the stdout
 		if (do_auto_refine)
 			checkConvergence(node->rank == 1);
 
@@ -3087,9 +3087,9 @@ void MlOptimiserMpi::iterate()
 		if (do_skip_maximization)
 		{
 			// Only write data.star file and break from the iteration loop
-			if (node->isMaster())
+			if (node->isLeader())
 			{
-				// The master only writes the data file (he's the only one who has and manages these data!)
+				// The leader only writes the data file (he's the only one who has and manages these data!)
 				iter = -1; // write output file without iteration number
 				MlOptimiser::write(DONT_WRITE_SAMPLING, DO_WRITE_DATA, DONT_WRITE_OPTIMISER, DONT_WRITE_MODEL, node->rank);
 				if (verb > 0)
@@ -3119,7 +3119,7 @@ void MlOptimiserMpi::iterate()
 		// Then helical symmetry is applied in Fourier space. It does rise and twist for all asymmetrical units in Fourier space.
 		// Finally it applies point group symmetry (such as Cn, ...).
 		// DEBUG
-		if ( (verb > 0) && (node->isMaster()) )
+		if ( (verb > 0) && (node->isLeader()) )
 		{
 			if ( (do_helical_refine) && (!ignore_helical_symmetry) && mymodel.ref_dim != 2 )
 			{
@@ -3136,7 +3136,7 @@ void MlOptimiserMpi::iterate()
 		}
 		symmetriseReconstructions();
 
-		if ( (verb > 0) && (node->isMaster()) && (fn_local_symmetry_masks.size() >= 1) && (fn_local_symmetry_operators.size() >= 1) )
+		if ( (verb > 0) && (node->isLeader()) && (fn_local_symmetry_masks.size() >= 1) && (fn_local_symmetry_operators.size() >= 1) )
 			std::cout << " Applying local symmetry in real space according to " << fn_local_symmetry_operators.size() << " operators..." << std::endl;
 
 		// Write out data and weight arrays to disc in order to also do an unregularized reconstruction
@@ -3168,7 +3168,7 @@ void MlOptimiserMpi::iterate()
 #endif
 
 			// For automated sampling procedure
-			if (!node->isMaster()) // the master does not have the correct mymodel.current_size, it only handles metadata!
+			if (!node->isLeader()) // the leader does not have the correct mymodel.current_size, it only handles metadata!
 			{
 
 				// Check that incr_size is at least the number of shells as between FSC=0.5 and FSC=0.143
@@ -3244,7 +3244,7 @@ void MlOptimiserMpi::iterate()
 #ifdef TIMING
 		timer.tic(TIMING_ITER_HELICALREFINE);
 #endif
-		if (node->isMaster())
+		if (node->isLeader())
 		{
 			if ( (do_helical_refine) && (!do_skip_align) && (!do_skip_rotate) && mymodel.ref_dim == 3)
 			{
@@ -3296,10 +3296,10 @@ void MlOptimiserMpi::iterate()
 			iter = -1;
 
 		if (node->rank == 1 || (do_split_random_halves && !do_join_random_halves && node->rank == 2))
-			//Only the first_slave of each subset writes model to disc (do not write the data.star file, only master will do this)
+			//Only the first_follower of each subset writes model to disc (do not write the data.star file, only leader will do this)
 			MlOptimiser::write(DO_WRITE_SAMPLING, DONT_WRITE_DATA, do_write_optimiser, DO_WRITE_MODEL, node->rank);
-		else if (node->isMaster())
-			// The master only writes the data file (he's the only one who has and manages these data!)
+		else if (node->isLeader())
+			// The leader only writes the data file (he's the only one who has and manages these data!)
 			MlOptimiser::write(DONT_WRITE_SAMPLING, DO_WRITE_DATA, DONT_WRITE_OPTIMISER, DONT_WRITE_MODEL, node->rank);
 
 #ifdef TIMING
@@ -3350,7 +3350,7 @@ void MlOptimiserMpi::iterate()
 		}
 
 #ifdef TIMING
-		// Only first slave prints it timing information
+		// Only first follower prints it timing information
 		if (node->rank == 1)
 			timer.printTimes(false);
 #endif

--- a/src/ml_optimiser_mpi.h
+++ b/src/ml_optimiser_mpi.h
@@ -39,8 +39,8 @@ public:
     // For debugging: keep temporary/debug weight and data mrc files
     bool do_keep_debug_reconstruct_files;
 
-    // For debugging: halt all slaves except this one
-    int halt_all_slaves_except_this;
+    // For debugging: halt all followers except this one
+    int halt_all_followers_except_this;
 
     // Original verb
     int ori_verb;
@@ -120,8 +120,8 @@ public:
      */
     void joinTwoHalvesAtLowResolution();
 
-    /** When refining two random halves separately, the master receives both models, calculates FSC and the power of their difference
-     *  and sends these curves, together with new tau2_class estimates to all slaves...
+    /** When refining two random halves separately, the leader receives both models, calculates FSC and the power of their difference
+     *  and sends these curves, together with new tau2_class estimates to all followers...
      */
     void compareTwoHalves();
 

--- a/src/motioncorr_runner_mpi.cpp
+++ b/src/motioncorr_runner_mpi.cpp
@@ -27,8 +27,8 @@ void MotioncorrRunnerMpi::read(int argc, char **argv)
 	// First read in non-parallelisation-dependent variables
 	MotioncorrRunner::read(argc, argv);
 
-	// Don't put any output to screen for mpi slaves
-	verb = (node->isMaster()) ? 1 : 0;
+	// Don't put any output to screen for mpi followers
+	verb = (node->isLeader()) ? 1 : 0;
 
 	// Print out MPI info
 	printMpiNodesMachineNames(*node);
@@ -36,8 +36,8 @@ void MotioncorrRunnerMpi::read(int argc, char **argv)
 
 void MotioncorrRunnerMpi::run()
 {
-	prepareGainReference(node->isMaster());
-	MPI_Barrier(MPI_COMM_WORLD); // wait for the master to write the gain reference
+	prepareGainReference(node->isLeader());
+	MPI_Barrier(MPI_COMM_WORLD); // wait for the leader to write the gain reference
 
 	// Each node does part of the work
 	long int my_first_micrograph, my_last_micrograph, my_nr_micrographs;
@@ -91,9 +91,8 @@ void MotioncorrRunnerMpi::run()
 
 	MPI_Barrier(MPI_COMM_WORLD);
 
-	// Only the master writes the joined result file
-	if (node->isMaster())
+	// Only the leader writes the joined result file
+	if (node->isLeader())
 		generateLogFilePDFAndWriteStarFiles();
 
 }
-

--- a/src/mpi.h
+++ b/src/mpi.h
@@ -73,16 +73,16 @@ class MpiNode
 public:
 	int rank, size;
 
-	MPI_Group worldG, slaveG; // groups of ranks (in practice only used to create communicators)
-	MPI_Comm worldC, slaveC; // communicators
-	int slaveRank; // index of slave within the slave-group (and communicator)
+	MPI_Group worldG, followerG; // groups of ranks (in practice only used to create communicators)
+	MPI_Comm worldC, followerC; // communicators
+	int followerRank; // index of follower within the follower-group (and communicator)
 
 	MpiNode(int &argc, char ** argv);
 
 	~MpiNode();
 
 	// Only true if rank == 0
-	bool isMaster() const;
+	bool isLeader() const;
 
 	// Prints the random subset for this rank
 	int myRandomSubset() const;

--- a/src/preprocessing_mpi.cpp
+++ b/src/preprocessing_mpi.cpp
@@ -30,8 +30,8 @@ void PreprocessingMpi::read(int argc, char **argv)
 	int mpi_section = parser.addSection("MPI options");
 	max_mpi_nodes =textToInteger(parser.getOption("--max_mpi_nodes", "Limit the number of effective MPI nodes to protect from too heavy disk I/O (thus ignoring larger values from mpirun)", "8"));
 
-	// Don't put any output to screen for mpi slaves
-	verb = (node->isMaster()) ? 1 : 0;
+	// Don't put any output to screen for mpi followers
+	verb = (node->isLeader()) ? 1 : 0;
 
 	// Possibly also read parallelisation-dependent variables here
 
@@ -106,7 +106,7 @@ void PreprocessingMpi::runExtractParticles()
 	// Wait until all nodes have finished to make final star file
 	MPI_Barrier(MPI_COMM_WORLD);
 
-	if (node->isMaster())
+	if (node->isLeader())
 	{
 		if (verb > 0)
 			progress_bar(my_nr_mics);
@@ -122,7 +122,7 @@ void PreprocessingMpi::run()
 		runExtractParticles();
 	}
 	// The following has not been parallelised....
-	else if (fn_operate_in != "" && node->isMaster())
+	else if (fn_operate_in != "" && node->isLeader())
 		Preprocessing::runOperateOnInputFile();
 
 	if (verb > 0)

--- a/src/reconstructor_mpi.cpp
+++ b/src/reconstructor_mpi.cpp
@@ -27,8 +27,8 @@ void ReconstructorMpi::read(int argc, char **argv)
 	// First read in non-parallelisation-dependent variables
 	Reconstructor::read(argc, argv);
 
-	// Don't put any output to screen for mpi slaves
-	verb = (node->isMaster()) ? verb : 0;
+	// Don't put any output to screen for mpi followers
+	verb = (node->isLeader()) ? verb : 0;
 
 	// Possibly also read parallelisation-dependent variables here
 
@@ -58,7 +58,7 @@ void ReconstructorMpi::run()
 		MPI_Allreduce(MULTIDIM_ARRAY(backprojector.data), MULTIDIM_ARRAY(sumd), 2*MULTIDIM_SIZE(backprojector.data), MY_MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
 		MPI_Allreduce(MULTIDIM_ARRAY(backprojector.weight), MULTIDIM_ARRAY(sumw), MULTIDIM_SIZE(backprojector.weight), MY_MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
 
-		if (node->isMaster())
+		if (node->isLeader())
 		{
 			backprojector.data = sumd;
 			backprojector.weight = sumw;
@@ -66,7 +66,7 @@ void ReconstructorMpi::run()
 
 	}
 
-	if (node->isMaster())
+	if (node->isLeader())
 		reconstruct();
 
 }

--- a/src/reconstructor_mpi.h
+++ b/src/reconstructor_mpi.h
@@ -49,4 +49,3 @@ public:
 
 
 #endif /* RECONSTRUCTOR_MPI_H_ */
-


### PR DESCRIPTION
Hello RELION developers - 

Related to discussions of how to make science and cryoEM inclusive, we should consider removing 'master' and 'slave' from our code. To help facilitate this, I'm submitting this pull request where I replaced 'master' and 'slave' with 'leader' and 'follower,' respectively.

Some additional materials discussing this situation in the life sciences & computing:

- [Equity, Diversity and Inclusion: A call to eradicate non-inclusive terms from the life sciences](https://elifesciences.org/articles/65604)
- [Tech Confronts Its Use of the Labels ‘Master’ and ‘Slave’](https://www.wired.com/story/tech-confronts-use-labels-master-slave/)

I've tested the changes on my end without any issues in analyzing the tutorial dataset. 

If you prefer alternative terms I can also change and submit a different pull request. 

Thank you!
Mike

<img width="549" alt="Screen Shot 2021-02-23 at 12 27 50 PM" src="https://user-images.githubusercontent.com/1464469/108883928-01e16f80-75d4-11eb-9fad-f581de5dda08.png">
