### PR TITLE
Fixed buffer overflow in FileName::compose

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,11 +7,12 @@ assignees: ''
 
 ---
 
-This is a template for asking questions and reporting bugs. Please fill in as much information as you can.
+This is a template for reporting bugs. Please fill in as much information as you can.
 
 **Describe your problem**
 
 Please write a clear description of what the problem is.
+Data processing questions should be posted to [the CCPEM mailing list](https://www.jiscmail.ac.uk/cgi-bin/webadmin?A0=CCPEM), not here.
 **DO NOT** cross post a same question to multiple issues and/or many mailing lists (CCPEM, 3DEM, etc).
 
 **Environment:**

--- a/src/filename.cpp
+++ b/src/filename.cpp
@@ -73,7 +73,7 @@ void FileName::compose(long int no , const std::string &str, int numberlength)
 	if (no != -1)
 	{
 
-		char aux_str[numberlength+1];
+		char aux_str[numberlength+2];
 		std::string tmp_fileformat;
 		tmp_fileformat = (std::string) "%0" +
 		                 integerToString(numberlength)+


### PR DESCRIPTION
The temporary aux_str buffer  in Filename::compose(long int, const std::string &, int) needs to have a size of numberlength+2 (length of number + @ character + 0 terminator) instead of numberlength+1 to prevent it from overflowing in the sprintf function.