### PR TITLE
Fix for race condition during cleanup of local scratch.

### DIFF
--- a/src/ml_optimiser_mpi.cpp
+++ b/src/ml_optimiser_mpi.cpp
@@ -668,7 +668,10 @@ void MlOptimiserMpi::initialiseWorkLoad()
 
 				MPI_Barrier(MPI_COMM_WORLD);
 				if (!need_to_copy) // This initialises nr_parts_on_scratch on non-first ranks by pretending --reuse_scratch
+				{
 					mydata.setScratchDirectory(fn_scratch, true, verb);
+					keep_scratch=true; // Setting keep_scratch for non-first ranks, to ensure that only first rank on each node deletes scratch during cleanup
+				}
 			}
 			else
 			{


### PR DESCRIPTION
After a classification/refinement using a scratch directory is finished, each worker rank tries to delete the scratch directory.
This can lead to a race condition, where some of the rm -fr commands fail and where Relion aborts and marks the job as failed.
Setting keep_scratch=true for all ranks except the first on each node avoids the race condition, as only one rank per node performs the cleanup.