### PR TITLE
Enabled FLTK_SKIP_FLUID in CMakeLists.txt - Do not check for fltk fluid

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -291,6 +291,7 @@ option(FORCE_OWN_FLTK "FORCE_OWN_FLTK" OFF)
 FIND_PACKAGE(X11)
 if(GUI)
     if(X11_FOUND)
+        set(FLTK_SKIP_FLUID TRUE) #FLUID is not required for relion
         set(FLTK_SKIP_OPENGL TRUE) #OpenGL is not required for relion
         if(NOT FORCE_OWN_FLTK)
             FIND_PACKAGE(FLTK)


### PR DESCRIPTION
Dear All,
on some distributions like RH derivates, when fltk is coming from repos, you get errors related to the absence of the command fluid in FLTK that require manual modifications in some files generated by cmake. If the FLTK_SKIP_FLUID parameter is appropriately configured in the CMakeLists.txt file, the errors found disappear. Since from my tests the presence of fluid is not binding on the correct functioning of the relion gui, I propose the following modification. 

Greetings,
    Paolo