### PR TITLE
Add CI based on Github Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,37 @@
+on: [ pull_request ]
+
+name: Build RELION
+
+jobs:
+  build_on_x86_64:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install dependencies
+        run: |
+          sudo apt-get update -q -y && \
+          sudo apt-get install -q -y cmake git build-essential mpi-default-bin mpi-default-dev libfftw3-dev libtiff-dev libfltk1.3-dev
+      - name: Build RELION for Linux x86_64
+        run: mkdir build && cd build && cmake .. && make
+
+  build_on_aarch64:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build RELION for Linux aarch64
+        uses: uraimo/run-on-arch-action@v2
+        with:
+          arch: aarch64
+          distro: ubuntu20.04
+          githubToken: ${{ github.token }}
+          dockerRunArgs: |
+            --volume "${PWD}:/relion" 
+          install: |
+            apt-get update -q -y
+            apt-get install -q -y cmake git build-essential mpi-default-bin mpi-default-dev libfftw3-dev libtiff-dev libfltk1.3-dev
+          run: |
+            cd /relion
+            mkdir build
+            cd build
+            cmake ..
+            make


### PR DESCRIPTION
It runs on Github-hosted runner natively for Linux x86_64 and in a
emulated (QEMU) Docker container for Linux aarch64

Rlated-to: #896 