### PR TITLE
Fix for LLVM-based compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -258,7 +258,7 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "Intel" OR "${CMAKE_CXX_COMPILER}" MATCHES
         if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel")
             SET(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -qopenmp -mkl=parallel -limf ")
         else()	# Intel oneAPI compiler
-            SET(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fiopenmp -mkl=parallel -limf ")
+            SET(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fiopenmp -qmkl=parallel -limf ")
         endif()
     endif(MKLFFT)
     if(ALTCPU)


### PR DESCRIPTION
The existing "#pragma omp simd" in diff2_coarse function in CPU accelerated code is wrong since it requires private copy of partial array(diff2s) for SIMD vectorization. It is not supported by OpenMP standard. And this is causing incorrect result on LLVM-based compilers(Clang, Intel oneAPI, AMD AOCC, ARM clang, ...) while Intel and GCC compilers are okay.

And there is one fix for CMakeList.txt. It will fix Intel oneAPI compiler MKL support and this change is already applied "relion-devel" repo.