### PR TITLE
Grid-stride iteration and `ceilfracf`

### DIFF
--- a/src/acc/cpu/cpu_kernels/helper.cpp
+++ b/src/acc/cpu/cpu_kernels/helper.cpp
@@ -115,142 +115,79 @@ void RNDnormalDitributionComplexWithPowerModulation3D(ACCCOMPLEX* Image, size_t 
 		}
     }
 }
-void softMaskBackgroundValue(	int      block_dim,
-                                int      block_size,
-                                XFLOAT  *vol,
-								long int vol_size,
-								long int xdim,
-								long int ydim,
-								long int zdim,
-								long int xinit,
-								long int yinit,
-								long int zinit,
-								XFLOAT   radius,
-								XFLOAT   radius_p,
-								XFLOAT   cosine_width,
-								XFLOAT  *g_sum,
-								XFLOAT  *g_sum_bg)
-{
-	for(int bid=0; bid<block_dim; bid++)
-	{
-		for(int tid=0; tid<block_size; tid++)
-		{
-	//		vol.setXmippOrigin(); // sets xinit=xdim , also for y z
-			XFLOAT r, raisedcos;
-			int x,y,z;
-			XFLOAT     img_pixels;
 
-			size_t texel_pass_num = ceilfracf((size_t)vol_size,(size_t)block_size*(size_t)block_dim);
-			size_t texel = (size_t)bid*(size_t)block_size*(size_t)texel_pass_num + tid;
+void softMaskBackgroundValue(
+	int grid_dim, int block_dim,
+	XFLOAT *vol, long int vol_size,
+	long int xdim,  long int ydim,  long int zdim,
+	long int xinit, long int yinit, long int zinit,
+	XFLOAT radius, XFLOAT radius_p, XFLOAT cosine_width,
+	XFLOAT *g_sum, XFLOAT *g_sum_bg
+) {
+    const size_t stride = block_dim * grid_dim;
+    const size_t xydim = xdim * ydim;
 
-			for (size_t pass = 0; pass < texel_pass_num; pass++, texel+=block_size) // loop through all translations for this orientation
-			{
-				if(texel<vol_size)
-				{
-					img_pixels = vol[texel];
+    const auto weight = [radius, radius_p, cosine_width] (XFLOAT r) -> XFLOAT {
+        return r < radius   ? 0.0 :
+               r > radius_p ? 1.0 :
+        #if defined(ACC_DOUBLE_PRECISION)
+        0.5  + 0.5  * cos (M_PI * (radius_p - r) / cosine_width);
+        #else
+        0.5f + 0.5f * cosf(M_PI * (radius_p - r) / cosine_width);
+        #endif
+    };
 
-					z =   texel / (xdim*ydim) ;
-					y = ( texel % (xdim*ydim) ) / xdim ;
-					x = ( texel % (xdim*ydim) ) % xdim ;
+	for (int bid = 0; bid < grid_dim;  bid++)
+	for (int tid = 0; tid < block_dim; tid++) {
+		for (size_t i = bid * blockDim.x + tid; i < vol_size; i += stride) {
+			const int z = i / xydim        - zinit;
+			const int y = i % xydim / xdim - yinit;
+			const int x = i % xydim % xdim - xinit;
 
-					z-=zinit;
-					y-=yinit;
-					x-=xinit;
+			const XFLOAT r = sqrt(XFLOAT(x * x + y * y + z * z));
+			const XFLOAT w = weight(r);
 
-					r = sqrt(XFLOAT(x*x + y*y + z*z));
-
-					if (r < radius)
-						continue;
-					else if (r > radius_p)
-					{
-						g_sum[tid]    += (XFLOAT)1.0;
-						g_sum_bg[tid] += img_pixels;
-					}
-					else
-					{
-	#if defined(ACC_DOUBLE_PRECISION)
-						raisedcos = 0.5 + 0.5  * cos ( (radius_p - r) / cosine_width * M_PI);
-	#else
-						raisedcos = 0.5 + 0.5  * cosf( (radius_p - r) / cosine_width * M_PI);
-	#endif
-						g_sum[tid] += raisedcos;
-						g_sum_bg[tid] += raisedcos * img_pixels;
-					}
-				}
-			}
-		} // tid
-	} // bid
+			g_sum   [tid] += w;
+			g_sum_bg[tid] += w * vol[i];
+		}
+	}
 }
+void cosineFilter(
+	int block_dim, int block_size,
+	XFLOAT *vol, long int vol_size,
+	long int xdim,  long int ydim,  long int zdim,
+	long int xinit, long int yinit, long int zinit,
+	bool do_noise, XFLOAT *noise,
+	XFLOAT radius, XFLOAT radius_p, XFLOAT cosine_width,
+	XFLOAT bg_value
+) {
+	const size_t stride = block_dim * grid_dim;
+    const size_t xydim = xdim * ydim;
 
+    const auto weight = [radius, radius_p, cosine_width] (XFLOAT r) -> XFLOAT {
+        return r < radius   ? 0.0 :
+               r > radius_p ? 1.0 :
+        #if defined(ACC_DOUBLE_PRECISION)
+        0.5  + 0.5  * cos (M_PI * (radius_p - r) / cosine_width);
+        #else
+        0.5f + 0.5f * cosf(M_PI * (radius_p - r) / cosine_width);
+        #endif
+    };
 
-void cosineFilter(	int      block_dim,
-					int      block_size,
-					XFLOAT  *vol,
-					long int vol_size,
-					long int xdim,
-					long int ydim,
-					long int zdim,
-					long int xinit,
-					long int yinit,
-					long int zinit,
-					bool     do_noise,
-					XFLOAT *noise,
-					XFLOAT   radius,
-					XFLOAT   radius_p,
-					XFLOAT   cosine_width,
-					XFLOAT   bg_value)
-{
-	for(int bid=0; bid<block_dim; bid++)
-	{
-		for(int tid=0; tid<block_size; tid++)
-		{
-//		vol.setXmippOrigin(); // sets xinit=xdim , also for y z
-			XFLOAT r, raisedcos, defVal;
-			int x,y,z;
-			XFLOAT     img_pixels;
+	for (int bid = 0; bid < grid_dim;  bid++)
+	for (int tid = 0; tid < block_dim; tid++) {
+		for (size_t i = bid * blockDim.x + tid; i < vol_size; i += stride) {
+			const int z = i / xydim        - zinit;
+			const int y = i % xydim / xdim - yinit;
+			const int x = i % xydim % xdim - xinit;
 
-			size_t texel_pass_num = ceilfracf((size_t)vol_size,(size_t)block_size*(size_t)block_dim);
-			size_t texel = (size_t)bid*(size_t)block_size*(size_t)texel_pass_num + tid;
+			const XFLOAT r = sqrt(XFLOAT(x * x + y * y + z * z));
+			const XFLOAT w = weight(r);
+			const XFLOAT bg = do_noise ? noise[i] : bg_value;
 
-			defVal = bg_value;
-			for (size_t pass = 0; pass < texel_pass_num; pass++, texel+=block_size) // loop the available warps enough to complete all translations for this orientation
-			{
-				if(texel<vol_size)
-				{
-					img_pixels= vol[texel];
-
-					z =   texel / (xdim*ydim) ;
-					y = ( texel % (xdim*ydim) ) / xdim ;
-					x = ( texel % (xdim*ydim) ) % xdim ;
-
-					z-=zinit;
-					y-=yinit;
-					x-=xinit;
-
-					r = sqrt(XFLOAT(x*x + y*y + z*z));
-
-					if(do_noise)
-                                		defVal = noise[texel];
-
-					if (r < radius)
-						continue;
-					else if (r > radius_p)
-						img_pixels=defVal;
-					else
-					{
-		#if defined(ACC_DOUBLE_PRECISION)
-						raisedcos = 0.5 + 0.5  * cos ( (radius_p - r) / cosine_width * M_PI);
-		#else
-						raisedcos = 0.5 + 0.5  * cosf( (radius_p - r) / cosine_width * M_PI);
-		#endif
-						img_pixels= img_pixels*(1-raisedcos) + defVal*raisedcos;
-
-					}
-					vol[texel]=img_pixels;
-				}
-			}
-		} // tid
-	} // bid
+			vol[i] = vol[i] * (1 - w) + bg * w;
+		}
+	}
 }
 
 template <typename T>

--- a/src/acc/cuda/cuda_kernels/cuda_device_utils.cuh
+++ b/src/acc/cuda/cuda_kernels/cuda_device_utils.cuh
@@ -42,7 +42,7 @@ static inline
 __device__ int ceilfracf(T1 a, T2 b)
 {
 //	return __float2int_ru(__fdividef( (float)a, (float)b ) );
-	return (int)(a/b + 1);
+	return ceilf(float(a) / float(b));
 }
 
 static inline


### PR DESCRIPTION
Hello Sjors, Dari, & co.!

I have come across what I believe to be a bug that affects pixel sampling in `cuda_kernel_softMaskBackgroundValue` and `cuda_kernel_cosineFilter`. These functions make use of `ceilfracf`:
https://github.com/3dem/relion/blob/dcab7933398a8b728e56a08ea1bb2539a5ba71d4/src/acc/cuda/cuda_kernels/cuda_device_utils.cuh#L42
So far as I can tell from its name and the places it is called from, `ceilfracf(a, b)` should return the least integer `n` such that `n * b >= a`. But, as is clear from its definition, it does not do that. In cases where `b` divides `a` with no remainder,
the present implementation will return the intended result + 1.

``` C++
template< typename T1, typename T2 >
static inline
__device__ int ceilfracf(T1 a, T2 b)
{
//	return __float2int_ru(__fdividef( (float)a, (float)b ) );
	return (int)(a/b + 1);
}
```

We want to return not `a / b + 1` but `ceilf(float(a) / float(b))`. Or, without casting to `float`: `a / b + bool(a % b)` (assuming `T1` and `T2` are integral types, which is true at all the present call sites).

``` C++
template <typename T1, typename T2>
static inline
__device__ int ceilfracf(T1 a, T2 b) {
    return ceilf(float(a) / float(b));
}
```

Now, why does this matter? As I said, `ceilfracf` is called from a handful of functions, including `cuda_kernel_softMaskBackgroundValue` and `cuda_kernel_cosineFilter`. In these places, it is being used to calculate the number of strides needed to iterate over some image data, given some number of parallel CUDA threads. In the pathological case, when the image size is divisible by the number of threads, there will be too great a gap between where the threads start, and pixels will be missed. For instance, given a 32 × 32 × 32 image, calling `cuda_kernel_softMaskBackgroundValue` with 128 threads per block and 128 blocks per grid (as is currently done), ~10k out of ~30k pixels will be ignored. The situation is less disastrous for larger images, since as `a` (the image size) increases, the relative error in `ceilfracf(a, b)` decreases. Given a 64 × 64 × 64 image, "only" ~15k out of ~260k (6%) get missed.

So, the most obvious fix is to change `ceilfracf` in the manner described above.

This brings me to my next point. Do we even need `ceilfracf`? It took me some time to convince myself that (when `ceilfracf` does what it should) `cuda_kernel_softMaskBackgroundValue` samples each pixel in the image exactly once. As it stands now, threads iterate over `vol` in block-sized strides. Each thread block passes over a different subspan of `vol`,
and each thread within a block samples that subspan once every `SOFTMASK_BLOCK_SIZE` pixels. The loop that controls this iteration increments two things: `texel` and a separate counter `pass`, which is unused in the body of the loop.
The loop checks two conditions on every iteration: whether `texel` has gone past the end of `vol`, and whether `pass` has gone past `texel_pass_num` (which, as I have explained, will sometimes be off by 1). There need only be one iterator to increment. `cuda_kernel_softMaskBackgroundValue` has been like this since [its inception in 2016](https://github.com/3dem/relion/commit/bf990d4ecadbfc75bb4c1610725ae73a2ff31690). It looks to me like the intention is to do a grid-stride loop. So, that is what I have tried to implement. I have taken the opportunity to get rid of the shared-memory array `img_pixels`, for which I saw no use, and to introduce a closure `weight`, defined outside the loop body and invoked within it. Now, there is not even any need for `ceilfracf`. We can dispense with it. I have similarly rewritten `cuda_kernel_softMaskOutsideMap` and `cuda_kernel_cosineFilter`. There are other functions that make use of `ceilfracf`, but they only do block-stride iteration. I think they are safe.

Best,
James
