### PR TITLE
make EER available

### DIFF
--- a/src/motioncorr_runner.cpp
+++ b/src/motioncorr_runner.cpp
@@ -511,6 +511,8 @@ bool MotioncorrRunner::executeMotioncor2(Micrograph &mic, int rank)
 
 	if (fn_mic.getExtension() == "tif" || fn_mic.getExtension() == "tiff")
 		command += " -InTiff " + fn_mic;
+	else if (fn_mic.getExtension() == "eer")
+		command += " -InEer " + fn_mic;
 	else
 		command += " -InMrc " + fn_mic;
 


### PR DESCRIPTION
It was not possible to call MotionCorr with EER files yet. This change should make the correct parameter available.