### PR TITLE
Swap relion_refine's blush and external_reconstruct descriptions

### DIFF
--- a/src/ml_optimiser.cpp
+++ b/src/ml_optimiser.cpp
@@ -1004,11 +1004,11 @@ void MlOptimiser::parseInitial(int argc, char **argv)
     do_skip_maximization = parser.checkOption("--skip_maximize", "Skip maximization step (only write out data.star file)?");
     failsafe_threshold = textToInteger(parser.getOption("--failsafe_threshold", "Maximum number of particles permitted to be handled by fail-safe mode, due to zero sum of weights, before exiting with an error (GPU only).", "40"));
 
-	do_blush = parser.checkOption("--blush", "Perform the reconstruction step outside relion_refine, e.g. for learned priors?)");
-	if (parser.checkOption("--blush_skip_spectral_trailing", "Skip spectral trailing during Blush reconstruction (WARNING: This may inflate resolution estimates)"))
+    do_blush = parser.checkOption("--blush", "Perform the reconstruction with the Blush algorithm.");
+    if (parser.checkOption("--blush_skip_spectral_trailing", "Skip spectral trailing during Blush reconstruction (WARNING: This may inflate resolution estimates)"))
 		blush_args += " --skip-spectral-trailing ";
 
-	do_external_reconstruct = parser.checkOption("--external_reconstruct", "Perform the reconstruction with the Blush algorithm.");
+    do_external_reconstruct = parser.checkOption("--external_reconstruct", "Perform the reconstruction step outside relion_refine, e.g. for learned priors?)");
     nr_iter_max = textToInteger(parser.getOption("--auto_iter_max", "In auto-refinement, stop at this iteration.", "999"));
     auto_ignore_angle_changes = parser.checkOption("--auto_ignore_angles", "In auto-refinement, update angular sampling regardless of changes in orientations for convergence. This makes convergence faster.");
     auto_resolution_based_angles= parser.checkOption("--auto_resol_angles", "In auto-refinement, update angular sampling based on resolution-based required sampling. This makes convergence faster.");
@@ -1558,7 +1558,7 @@ void MlOptimiser::initialise()
 #if defined _CUDA_ENABLED || defined _HIP_ENABLED
         int devCount;
         HANDLE_ERROR(accGPUGetDeviceCount(&devCount));
-        
+
         accGPUDeviceProp deviceProp;
         int compatibleDevices(0);
         // Send device count seen by this follower
@@ -3568,7 +3568,7 @@ void MlOptimiser::expectation()
             }
             else
                 HANDLE_ERROR(accGPUSetDevice(((MlDeviceBundle*)accDataBundles[i])->device_id));
-            
+
             size_t free, total, allocationSize;
             HANDLE_ERROR(accGPUMemGetInfo( &free, &total ));
 
@@ -10648,7 +10648,7 @@ void MlOptimiser::selfTranslateSubtomoStack2D(MultidimArray<RFLOAT> &img, const 
     MultidimArray<Complex> FT, Faux;
     transformer.FourierTransform(img, FT, true);
     Faux = FT;
-    
+
     shiftImageInFourierTransformWithTabSincos(Faux, FT, (RFLOAT)mymodel.ori_size, mymodel.ori_size, tab_sin, tab_cos, xshift, yshift);
     transformer.inverseFourierTransform(FT, img);
 


### PR DESCRIPTION
relion_refine currently states:

<pre>$ relion_refine

+++ RELION: command line arguments (with defaults for optional ones between parantheses) +++
...
          --failsafe_threshold (40) : Maximum number of particles permitted to be handled by fail-safe mode, due to zero sum of weights, before exiting with an error (GPU only).
                    <b>--blush (false) : Perform the reconstruction step outside relion_refine, e.g. for learned priors?)</b>
  --blush_skip_spectral_trailing (false) : Skip spectral trailing during Blush reconstruction (WARNING: This may inflate resolution estimates)
     <b>--external_reconstruct (false) : Perform the reconstruction with the Blush algorithm.</b>
              --auto_iter_max (999) : In auto-refinement, stop at this iteration.
...
</pre>

This swaps the two descriptions.