### PR TITLE
ManualPicker: automatically save when closing the window

### DIFF
--- a/src/displayer.cpp
+++ b/src/displayer.cpp
@@ -1982,7 +1982,10 @@ int pickerViewerCanvas::handle(int ev)
 			else if ( strcmp(m->label(), "Help") == 0 )
 				printHelp();
 			else if ( strcmp(m->label(), "Quit (CTRL-q)") == 0 )
-				exit(0);
+                        {
+                            saveCoordinates(false);
+                            exit(0);
+                        }
 			redraw();
 			return 1; // (tells caller we handled this event)
 		}

--- a/src/manualpicker.cpp
+++ b/src/manualpicker.cpp
@@ -582,7 +582,7 @@ void manualpickerGuiWindow::cb_menubar_quit(Fl_Widget* w, void* v)
 void manualpickerGuiWindow::cb_menubar_quit_i()
 {
 	cb_menubar_recount_i();
-	exit(0);
+	RELION_EXIT_SUCCESS;
 }
 
 void manualpickerGuiWindow::cb_closing(Fl_Widget* w, void* v)

--- a/src/manualpicker.cpp
+++ b/src/manualpicker.cpp
@@ -250,6 +250,7 @@ int manualpickerGuiWindow::fill()
 {
 	color(GUI_BACKGROUND_COLOR);
 
+	this->callback(cb_closing);
 
 	Fl_Menu_Bar *menubar = new Fl_Menu_Bar(0, 0, w(), 25);
 	if (do_allow_save)
@@ -580,8 +581,14 @@ void manualpickerGuiWindow::cb_menubar_quit(Fl_Widget* w, void* v)
 
 void manualpickerGuiWindow::cb_menubar_quit_i()
 {
-	cb_menubar_save_i();
+	cb_menubar_recount_i();
 	exit(0);
+}
+
+void manualpickerGuiWindow::cb_closing(Fl_Widget* w, void* v)
+{
+	manualpickerGuiWindow* T=(manualpickerGuiWindow*)w;
+	T->cb_menubar_quit_i();
 }
 
 void manualpickerGuiWindow::cb_menubar_recount(Fl_Widget* w, void* v)
@@ -589,6 +596,7 @@ void manualpickerGuiWindow::cb_menubar_recount(Fl_Widget* w, void* v)
 	manualpickerGuiWindow* T=(manualpickerGuiWindow*)v;
 	T->cb_menubar_recount_i();
 }
+
 void manualpickerGuiWindow::cb_menubar_recount_i()
 {
 
@@ -781,10 +789,6 @@ void ManualPicker::initialise()
 			global_lowpass = new_nyquist;
 		std::cout << " Set low-pass filter to " << global_lowpass << " due to downscaling of " << global_micscale << std::endl;
 	}
-
-	std::cerr << " NOTE: in order to write the new list of coordinate STAR files, you need to re-count the particles or quite this program through the File menu. Do NOT kill the program using the operating system's window manager!" << std::endl;
-
-
 }
 
 void ManualPicker::run()

--- a/src/manualpicker.cpp
+++ b/src/manualpicker.cpp
@@ -582,7 +582,7 @@ void manualpickerGuiWindow::cb_menubar_quit(Fl_Widget* w, void* v)
 void manualpickerGuiWindow::cb_menubar_quit_i()
 {
 	cb_menubar_recount_i();
-	RELION_EXIT_SUCCESS;
+	exit(0);
 }
 
 void manualpickerGuiWindow::cb_closing(Fl_Widget* w, void* v)

--- a/src/manualpicker.h
+++ b/src/manualpicker.h
@@ -104,6 +104,8 @@ private:
     static void cb_menubar_quit(Fl_Widget*, void*);
     inline void cb_menubar_quit_i();
 
+    static void cb_closing(Fl_Widget*, void*);
+
     static void cb_menubar_recount(Fl_Widget*, void*);
     inline void cb_menubar_recount_i();
 


### PR DESCRIPTION
ManualPicker says:

> NOTE: in order to write the new list of coordinate STAR files, you need to re-count the particles or quite this program through the File menu. Do NOT kill the program using the operating system's window manager!

but this is not user-friendly. Most people don't notice this message, and even if they do see this, they just forget to use the menu.

With this patch, ManualPicker automatically saves the list even when closed by the window manager.

This also fixes a problem in the `[File]-[Quit]` menu. It used to save the list *without* recounting. Now it recounts and then saves the list.