### PR TITLE
Update CMakeLists to support newer CMake versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,10 +136,11 @@ endif()
  #This *has* to be AFTER project()
 include(${CMAKE_SOURCE_DIR}/cmake/BuildTypes.cmake)
 
-if(CUDA)
-    # -----------------------------------------------------------------------------CUDA--
-    # DOC: https://cmake.org/cmake/help/v3.28/module/FindCUDA.html
-    FIND_PACKAGE(CUDAToolkit)
+if(CMAKE_VERSION VERSION_LESS 3.10)
+	FIND_PACKAGE(CUDA)
+else(CMAKE_VERSION)
+	# newer version of CMake use a different module name
+	FIND_PACKAGE(CUDAToolkit)
 endif()
 
 if(CUDA_FOUND)


### PR DESCRIPTION
FIND_PACKAGE(CUDA) was deprecated starting with cmake 3.10 and flat out removed in cmake 3.27. For machines in environments with strict update requirements, this breaks compilation on newer systems.

FIND_PACKAGE(CUDAToolkit) works the exact same way, and is supported by cmake.

Thanks to the NERSC team for identifying the issue.