### PR TITLE
Relion 5 tomo: implement surfaces picker

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -6,6 +6,7 @@ dependencies:
   - pip
   - python=3.10
   - setuptools=59.5.0
+  - cgal=5.6.1
   - pip:
       - torch==2.0.1
       - torchvision==0.15.2

--- a/src/tomography_python_programs/_utils/cgal.py
+++ b/src/tomography_python_programs/_utils/cgal.py
@@ -1,0 +1,64 @@
+import numpy as np
+
+from typing import Tuple
+
+from CGAL.CGAL_Polyhedron_3 import Polyhedron_modifier, Polyhedron_3
+from CGAL.CGAL_Kernel import Point_3
+from CGAL.CGAL_Polygon_mesh_processing import isotropic_remeshing, compute_vertex_normals, remove_isolated_vertices
+
+def _vec2tuple(vec):
+    return vec.x(), vec.y(), vec.z()
+
+class Polyhedron(Polyhedron_3):
+    def __init__(self, vertices: np.array, indices: np.array):
+        super().__init__()
+        m = Polyhedron_modifier()
+
+        m.begin_surface(len(vertices), len(indices))
+        for vertex in vertices:
+            m.add_vertex(Point_3(*vertex))
+
+        for facet in indices:
+            m.begin_facet()
+            for i in facet:
+                    m.add_vertex_to_facet(int(i))
+            m.end_facet()
+
+        self.delegate(m)
+        m.clear()
+
+    def isotropic_remeshing(self, edge_length: float):
+        isotropic_remeshing(self.facets(), edge_length, self, 1)
+
+    def remove_isolated_vertices(self):
+        remove_isolated_vertices(self)
+
+    def vertices_array_shape(self) -> Tuple[int, int]:
+        return self.size_of_vertices(), 3
+    
+    def indices_array_shape(self) -> Tuple[int, int]:
+        return self.size_of_facets(), 3
+
+    def compute_vertex_normals(self) -> np.array:
+        out = np.zeros(self.vertices_array_shape(), dtype=float, order="C")
+        l = list()
+        compute_vertex_normals(self, l)
+        out[:] = list(map(_vec2tuple, l))
+        return out
+
+    def vertices_array(self) -> np.array:
+        out = np.zeros(self.vertices_array_shape(), dtype=float)
+        for i, v in enumerate(self.vertices()):
+            p = v.point()
+            out[i] = p.x(), p.y(), p.z()
+        return out
+
+    def indices_array(self) -> np.array:
+        out = np.zeros(self.indices_array_shape(), dtype=int)
+        raw_vertices = list(self.vertices())
+        for i, f in enumerate(self.facets()):
+            halfedge = f.halfedge()
+            out[i, 0] = raw_vertices.index(halfedge.vertex())
+            out[i, 1] = raw_vertices.index(halfedge.next().vertex())
+            out[i, 2] = raw_vertices.index(halfedge.next().next().vertex())
+        return out

--- a/src/tomography_python_programs/get_particle_poses/__init__.py
+++ b/src/tomography_python_programs/get_particle_poses/__init__.py
@@ -3,5 +3,6 @@
 from .particles import combine_particle_annotations
 from .spheres import derive_poses_on_spheres
 from .filaments import get_poses_along_filament_backbones
+from .surfaces import derive_poses_on_surfaces
 
 from ._cli import cli

--- a/src/tomography_python_programs/get_particle_poses/surfaces.py
+++ b/src/tomography_python_programs/get_particle_poses/surfaces.py
@@ -1,0 +1,95 @@
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import starfile
+import typer
+from scipy.spatial.transform.rotation import Rotation as R
+
+from ._cli import cli
+from .._utils.relion import relion_pipeline_job
+from .._utils.cgal import Polyhedron
+
+COMMAND_NAME = 'surfaces'
+
+def vec2euler(vec: np.ndarray, random_rot: bool=True) -> np.ndarray:
+    """Vector is [Z, Y, X] of shape (3,) or (N, 3). The vectors have to be normalized.
+    Returns array of shape (N, 3) with [rot, tilt, psi] in radians."""
+    vec = vec.reshape((-1, 3))
+    out = np.empty_like(vec, dtype=float)
+    # psi: rotation around global Z axis
+    np.arctan2(vec[:, 1], -vec[:, 2], out=out[:, 2])
+    # tilt: rotation around new Y axis
+    np.arccos(vec[:, 0], out=out[:, 1])
+    # rot: rotation around new Z axis (random)
+    if random_rot:
+        out[:, 0] = np.random.rand(len(out)) * 2 * np.pi - np.pi
+    else:
+        out[:, 0] = 0
+    return out
+
+
+@cli.command(name=COMMAND_NAME, no_args_is_help=True)
+@relion_pipeline_job
+def derive_poses_on_surfaces(
+    tilt_series_star_file: Path = typer.Option(
+        ..., help='tilt-series STAR file containing tomogram'
+    ),
+    annotations_directory: Path = typer.Option(
+        ..., help='directory containing annotations in each tomogram'
+    ),
+    output_directory: Path = typer.Option(
+        ..., help="directory into which 'particles.star' will be written."
+    ),
+    spacing_angstroms: float = typer.Option(
+        ..., help="target spacing between particle poses on spheres in angstroms."
+    ),
+):
+    global_df = starfile.read(tilt_series_star_file)
+    global_df = global_df.set_index('rlnTomoName')
+    annotation_files = annotations_directory.glob('*_surfaces.npz')
+    dfs = []
+    for file in annotation_files:
+        surface_file = np.load(file)
+        tilt_series_id = '_'.join(file.name.split('_')[:-1])
+        pixel_size = float(global_df.loc[tilt_series_id, 'rlnTomoTiltSeriesPixelSize'])
+        scale_factor = float(global_df.loc[tilt_series_id, 'rlnTomoTomogramBinning'])
+
+        polyhedron = Polyhedron(
+            surface_file['vertices'] * scale_factor,
+            surface_file['indices']
+        )
+        polyhedron.remove_isolated_vertices()
+        polyhedron.isotropic_remeshing(spacing_angstroms * pixel_size)
+        vertices = polyhedron.vertices_array()
+        normals = polyhedron.compute_vertex_normals()
+        assert len(vertices) == len(normals)
+        eulers = np.rad2deg(vec2euler(normals))
+        assert len(vertices) == len(eulers)
+        data = {
+            'rlnTomoName': [tilt_series_id] * len(vertices),
+            'rlnCoordinateX': vertices[:, 2],
+            'rlnCoordinateY': vertices[:, 1],
+            'rlnCoordinateZ': vertices[:, 0],
+            'rlnTomoSubtomogramRot': eulers[:, 0],
+            'rlnTomoSubtomogramTilt': eulers[:, 1],
+            'rlnTomoSubtomogramPsi': eulers[:, 2],
+        }
+        dfs.append(pd.DataFrame(data))
+    df = pd.concat(dfs)
+    rotated_basis = R.from_euler('y', angles=90, degrees=True).as_matrix()
+    rot_prior, tilt_prior, psi_prior = R.from_matrix(rotated_basis).as_euler(
+        seq='ZYZ', degrees=True
+    )
+    df['rlnAngleRot'] = [rot_prior] * len(df)
+    df['rlnAngleTilt'] = [tilt_prior] * len(df)
+    df['rlnAnglePsi'] = [psi_prior] * len(df)
+    df['rlnAngleTiltPrior'] = [tilt_prior] * len(df)
+    df['rlnAnglePsiPrior'] = [psi_prior] * len(df)
+    output_file = output_directory / 'particles.star'
+    starfile.write({'particles': df}, output_file, overwrite=True)
+
+    df2 = pd.DataFrame({'rlnTomoParticlesFile' : [output_file],
+                        'rlnTomoTomogramsFile' : [tilt_series_star_file]})
+    opt_file = output_directory / 'optimisation_set.star'
+    starfile.write({'optimisation_set': df2}, opt_file, overwrite=True)

--- a/src/tomography_python_programs/pick/__init__.py
+++ b/src/tomography_python_programs/pick/__init__.py
@@ -1,5 +1,6 @@
 from .particles import pick_particles
 from .spheres import pick_spheres
 from .filaments import pick_filaments
+from .surfaces import pick_surfaces
 
 from ._cli import cli

--- a/src/tomography_python_programs/pick/surfaces.py
+++ b/src/tomography_python_programs/pick/surfaces.py
@@ -1,0 +1,153 @@
+from pathlib import Path
+from typing import Optional, Tuple
+
+import napari
+import napari.layers
+import numpy as np
+from qtpy.QtWidgets import QWidget, QVBoxLayout, QPushButton, QSizePolicy
+from magicgui.widgets import create_widget
+from typer import Option
+
+from ._cli import cli
+from .._metadata_models.relion.tilt_series_set import RlnTiltSeriesSet
+from .._metadata_models.gui.tilt_series_set import GuiTiltSeriesSet
+from .._qt.components.tomogram_browser import TomogramBrowserWidget
+from .._qt.components.save_dialog import SaveDialog
+from .._utils.relion import relion_pipeline_job
+
+COMMAND_NAME = 'surfaces'
+
+
+class PickSurfacesWidget(QWidget):
+    def __init__(
+        self,
+        viewer: napari.Viewer,
+        tilt_series: GuiTiltSeriesSet,
+        output_directory: Path,
+        cache_size: int = 3,
+        *args,
+        **kwargs
+    ):
+        super().__init__(*args, **kwargs)
+        self.viewer = viewer
+        self.output_directory = output_directory
+        self._surface_layer_combo = create_widget(
+            value=None,
+            annotation=Optional[napari.layers.Surface],
+            label="Surface layer",
+        )
+        self.viewer.layers.events.inserted.connect(self._surface_layer_combo.reset_choices)
+        self.viewer.layers.events.removed.connect(self._surface_layer_combo.reset_choices)
+        self.viewer.layers.events.reordered.connect(self._surface_layer_combo.reset_choices)
+
+        self.tomogram_browser_widget = TomogramBrowserWidget(
+            viewer=viewer,
+            tilt_series=tilt_series,
+            cache_size=cache_size,
+        )
+        self.save_button = QPushButton('save surfaces')
+        self.save_button.setToolTip(
+            'save surfaces for the current tomogram to disk.'
+        )
+
+        self.tomogram_browser_widget.changing_tomogram.connect(
+            self._open_save_dialog
+        )
+        self.tomogram_browser_widget.tomogram_changed.connect(
+            self.synchronise_annotator
+        )
+        self.save_button.clicked.connect(self.save_particles)
+
+        self.setLayout(QVBoxLayout())
+        self.layout().addWidget(self.tomogram_browser_widget)
+        self.layout().addWidget(self._surface_layer_combo.native)
+        self.layout().addWidget(self.save_button)
+        self.tomogram_browser_widget.setSizePolicy(QSizePolicy.Expanding,
+                                                   QSizePolicy.Expanding)
+        self.tomogram_browser_widget.layout().setContentsMargins(0, 0, 0, 0)
+        self.synchronise_annotator()
+
+    def synchronise_annotator(self):
+        surface_layer = self._surface_layer_combo.value
+        if surface_layer is not None:
+            self.viewer.layers.remove(surface_layer)
+        try:
+            layer_data = self.load_particles()
+            self._surface_layer_combo.value = self.viewer.add_surface(layer_data)
+        except FileNotFoundError:
+            pass
+        self.viewer.layers.selection = [self.tomogram_browser_widget.image_layer]
+
+    @property
+    def current_particle_star_file(self) -> Path:
+        tilt_series_id = self.tomogram_browser_widget.selected_tilt_series.name
+        return self.output_directory / 'annotations' / f'{tilt_series_id}_surfaces.star'
+
+    @property
+    def current_surfaces_file(self) -> Path:
+        return self.current_particle_star_file.with_suffix(".npz")
+
+    def surface_empty(self) -> bool:
+        vertices, indices = self.vertices_indices()
+        return vertices is None or indices is None or len(vertices) == 0 or len(indices) == 0
+
+    def vertices_indices(self) -> Tuple[Optional[np.ndarray], Optional[np.ndarray]]:
+        if self._surface_layer_combo.value is None:
+            return None, None
+        surface_data = self._surface_layer_combo.value.data
+        if len(surface_data) == 2:
+            vertices, indices = surface_data
+        else:
+            vertices, indices, _ = surface_data
+        return vertices, indices
+
+    def save_particles(self):
+        if self.surface_empty():
+            raise ValueError('no surfaces to save')
+        vertices, indices = self.vertices_indices()
+        output_directory = self.current_particle_star_file.parent
+        output_directory.mkdir(parents=True, exist_ok=True)
+        np.savez_compressed(self.current_surfaces_file, vertices=vertices, indices=indices)
+
+    def load_particles(self) -> Tuple[np.ndarray, np.ndarray]:
+        file = np.load(self.current_surfaces_file)
+        return file["vertices"], file["indices"]
+
+    def _open_save_dialog(self):
+        if self.surface_empty():
+            return
+        dlg = SaveDialog(self)
+        dlg.buttonBox.accepted.connect(self.save_particles)
+        dlg.buttonBox.accepted.connect(dlg.close)
+        dlg.buttonBox.rejected.connect(dlg.close)
+        dlg.exec()
+
+
+@cli.command(name=COMMAND_NAME, no_args_is_help=True)
+@relion_pipeline_job
+def pick_surfaces(
+    tilt_series_star_file: Path = Option(...),
+    output_directory: Path = Option(...),
+    cache_size: int = 3
+):
+    viewer = napari.Viewer(ndisplay=3)
+    relion_tilt_series_set = RlnTiltSeriesSet.from_star_file(tilt_series_star_file)
+    gui_tilt_series_set = relion_tilt_series_set.as_gui_model()
+    dock_widget = PickSurfacesWidget(
+        viewer=viewer,
+        tilt_series=gui_tilt_series_set,
+        output_directory=output_directory,
+        cache_size=cache_size
+    )
+    viewer.window.add_dock_widget(
+        dock_widget, name='RELION: 3D surface picker', area='left'
+    )
+    viewer.axes.visible = True
+    viewer.axes.labels = False
+    viewer.camera.angles = (-15, 30, 150)
+    viewer.camera.zoom *= 0.7
+    viewer.text_overlay.text = """
+    Load a surface into napari by e.g. dragging an IMOD model into the viewer.
+    """
+    viewer.text_overlay.visible = True
+    napari.run()


### PR DESCRIPTION
Hello,

I implemented a function to pick particles on surface meshes in napari.

It uses CGAL to remesh the input surface with a fixed edge length and uses the vertices as point coordinates. The surface normal vectors (also calculated using CGAL) are used to derive initial particle rotation angles.
The functionality is essentially the same as implemented [here](https://github.com/Chlanda-Lab/napari-surface-picker).

What is currently still not quite working is the euler angle calculation. However, I first wanted to check if you're even interested in this pull request before I start messing with that.