### PR TITLE
Initialize pre_exposure_micrographs for glob-style input

### DIFF
--- a/src/motioncorr_runner.cpp
+++ b/src/motioncorr_runner.cpp
@@ -288,7 +288,8 @@ void MotioncorrRunner::initialise()
 	else
 	{
 		fn_in.globFiles(fn_micrographs);
-		optics_group_micrographs.resize(fn_in.size(), 1);
+		optics_group_micrographs.resize(fn_micrographs.size(), 1);
+		pre_exposure_micrographs.resize(fn_micrographs.size(), 0.0);
 		obsModel.opticsMdt.clear();
 		obsModel.opticsMdt.addObject();
 	}


### PR DESCRIPTION
When provided a glob of movie filenames instead of a .star file as the input --i parameter, initialize the `pre_exposure_micrographs` vector to 0.0 for all input movies.

Absent this, relion_run_motioncorr in ver5.0 with glob input segfaults at motioncorr_runner.cpp line 518 when attempting to recall per-movie additional pre-exposures.