### PR TITLE
Add average of power spectra for helical samples.

### DIFF
--- a/src/displayer.h
+++ b/src/displayer.h
@@ -145,7 +145,7 @@ public:
 	               RFLOAT _scale, RFLOAT _ori_scale, int _ncol, long int max_nr_images = -1, RFLOAT lowpass = -1.0 , RFLOAT highpass = -1.0,
 	               bool do_class = false, MetaDataTable *MDdata = NULL,
 	               int _nr_regroup = -1, bool do_recenter = false, bool _is_data = false, MetaDataTable *MDgroups = NULL,
-	               bool do_allow_save = false, FileName fn_selected_imgs="", FileName fn_selected_parts="", int max_nr_parts_per_class = -1);
+	               bool do_allow_save = false, FileName fn_selected_imgs="", FileName fn_selected_parts="", int max_nr_parts_per_class = -1, bool _show_fourier_amplitudes = false, bool _show_fourier_phase_angles = false);
 	int fillSingleViewerCanvas(MultidimArray<RFLOAT> image, RFLOAT _minval, RFLOAT _maxval, RFLOAT _sigma_contrast, RFLOAT _scale);
 	int fillPickerViewerCanvas(MultidimArray<RFLOAT> image, RFLOAT _minval, RFLOAT _maxval, RFLOAT _sigma_contrast, RFLOAT _scale, RFLOAT _coord_scale,
 	                           int _particle_radius, bool do_startend = false, FileName _fn_coords = "",
@@ -168,6 +168,11 @@ public:
 	int ysize_box;
 	int xoff;
 	int yoff;
+	// Show Fourier amplitudes?
+	bool show_fourier_amplitudes;
+
+	// Show Fourier phase angles?
+	bool show_fourier_phase_angles;
 
 	// To get positions in scrolled canvas...
 	Fl_Scroll *scroll;
@@ -277,6 +282,8 @@ private:
 	void makeStarFileSelectedParticles(int save_selected, MetaDataTable &MDpart);
 	void saveSelectedParticles(int save_selected);
 	void showSelectedParticles(int save_selected);
+	void showSelectedFourierAmplitudes(int save_selected);
+	void showSelectedFourierPhaseAngles(int save_selected);
 	void saveTrainingSet();
 	void saveSelected(int save_selected);
 	void saveBackupSelection();

--- a/src/fftw.cpp
+++ b/src/fftw.cpp
@@ -1306,7 +1306,7 @@ void LoGFilterMap(MultidimArray<RFLOAT > &img, RFLOAT sigma, RFLOAT angpix)
 		}
 		else
 		{
-			REPORT_ERROR("lowPassFilterMap: filtering of non-cube maps is not implemented...");
+			REPORT_ERROR("LoGFilterMap: filtering of non-cube maps is not implemented...");
 		}
 	}
 	transformer.FourierTransform(img, FT, false);
@@ -1322,7 +1322,7 @@ void LoGFilterMap(MultidimArray<RFLOAT > &img, RFLOAT sigma, RFLOAT angpix)
 		}
 		else
 		{
-			REPORT_ERROR("lowPassFilterMap: filtering of non-cube maps is not implemented...");
+			REPORT_ERROR("LoGFilterMap: filtering of non-cube maps is not implemented...");
 		}
 	}
 
@@ -1547,7 +1547,7 @@ void directionalFilterMap(MultidimArray<RFLOAT > &img, RFLOAT low_pass, RFLOAT a
 		}
 		else
 		{
-			REPORT_ERROR("lowPassFilterMap: filtering of non-cube maps is not implemented...");
+			REPORT_ERROR("directionalFilterMap: filtering of non-cube maps is not implemented...");
 		}
 	}
 	transformer.FourierTransform(img, FT, false);
@@ -1563,7 +1563,7 @@ void directionalFilterMap(MultidimArray<RFLOAT > &img, RFLOAT low_pass, RFLOAT a
 		}
 		else
 		{
-			REPORT_ERROR("lowPassFilterMap: filtering of non-cube maps is not implemented...");
+			REPORT_ERROR("directionalFilterMap: filtering of non-cube maps is not implemented...");
 		}
 	}
 
@@ -1702,21 +1702,22 @@ void amplitudeOrPhaseMap(const MultidimArray<RFLOAT > &v, MultidimArray<RFLOAT >
 	maxr2 = (XYdim - 1) * (XYdim - 1) / 4;
 	FOR_ALL_ELEMENTS_IN_FFTW_TRANSFORM2D(Faux)
 	{
+		long int r2 = ip * ip + jp * jp;
 		if ( (ip > STARTINGY(out)) && (ip < FINISHINGY(out))
 				&& (jp > STARTINGX(out)) && (jp < FINISHINGX(out))
-				&& ((ip * ip + jp * jp) < maxr2) )
+				&& (r2 < maxr2) )
 		{
 			if (output_map_type == AMPLITUDE_MAP)
-				val = FFTW2D_ELEM(Faux, ip, jp).abs();
+				// Down-weight the 10 pixels around origin for better visualization
+				val = (1.0-exp(-r2/100.0))*FFTW2D_ELEM(Faux, ip, jp).abs();
 			else if (output_map_type == PHASE_MAP)
 				val = (180.) * (FFTW2D_ELEM(Faux, ip, jp).arg()) / PI;
 			else
 				REPORT_ERROR("fftw.cpp::amplitudeOrPhaseMap(): ERROR Unknown type of output map.");
-
 			A2D_ELEM(out, -ip, -jp) = A2D_ELEM(out, ip, jp) = val;
 		}
 	}
-	A2D_ELEM(out, 0, 0) = 0.;
+	//A2D_ELEM(out, 0, 0) = 0.;
 	amp.clear();
 	amp = out;
 }


### PR DESCRIPTION
Dear Developers,

We have implemented a new feature that allows for the creation of an average power spectrum from the individual power spectra of images within selected 2D classes. This approach differs from calculating the power spectrum of a single 2D class average and is particularly useful for reducing artifacts when working with helical assemblies.

The procedure involves two steps:

In the display window showing 2D classes, right-click on a selected 2D class average and choose the new option "Show Fourier amplitudes (2x) from selected classes."
In the newly opened display window, select all the boxes, right-click, and choose "Show average of selection" from the menu.

Best wishes,

Ambroise Desfosses and Leandro F. Estrozi.