### PR TITLE
fix: Correct dyadicProduct method in Tensor2x2 class

### DIFF
--- a/src/jaz/math/tensor2x2.h
+++ b/src/jaz/math/tensor2x2.h
@@ -149,12 +149,9 @@ class Tensor2x2
     {
         Tensor2x2<T> out;
 
-        out.xx = v0.x0 * v1.x1;
-        out.xy = v0.x0 * v1.y1;
-        out.xz = v0.x0 * v1.z1;
-        out.yy = v0.y0 * v1.y1;
-        out.yz = v0.y0 * v1.z1;
-        out.zz = v0.z0 * v1.z1;
+        out.xx = v0.x * v1.x;
+        out.xy = v0.x * v1.y;
+        out.yy = v0.y * v1.y;
 
         return out;
     }


### PR DESCRIPTION
**Description:**
- Corrected references to non-existent members `xz`, `yz`, `zz`, `x0`, `y0`, `z0` in the `dyadicProduct` method.
- The method now correctly uses the existing members `xx`, `xy`, `yy` in line with the class definition.

**Impact:**
- Fixes compilation errors and ensures logical consistency with `Tensor2x2`'s definition.

**Testing:**
- Verified compilation and basic functionality after the fix.

**Compiling Environment:**
- macOS 14.7 with CPU-only configuration.
- Homebrew clang version 19.1.1 used for compilation.