### PR TITLE
fixes UB in `void removeQuotes(char **_str)` implemented in src/strings.cpp

### DIFF
--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -470,15 +470,14 @@ std::string removeSpaces(const std::string& _str)
 // Remove quotes ===========================================================
 void removeQuotes(char **_str)
 {
+	if (!_str || !*_str) { return; }
 	std::string retval = *_str;
-	if (retval.length() == 0)
+	if (retval.empty())
 		return;
-	char c = retval[0];
-	if (c == '\"' || c == '\'')
-		retval = retval.substr(1, retval.length() - 1);
-	c = retval[retval.length()-1];
-	if (c == '\"' || c == '\'')
-		retval = retval.substr(0, retval.length() - 1);
+	if (retval[0] == '\"' || retval[0] == '\'')
+		retval = retval.substr(1);
+	if (!retval.empty() && (retval.back() == '\"' || retval.back() == '\''))
+		retval.pop_back();
 	free(*_str);
 	*_str = strdup(retval.c_str());
 }


### PR DESCRIPTION
This pull request addresses #1200

### What has been changed:
added null checks for `_str` and fixed overflow runtime error caused by back quote checking. I wanted to throw `REPORT_ERROR` on null check for `_str` but wasn't sure what could be a suitable message. Please let me know if you have any questions or suggestions.