### PR TITLE
ctffind_runner better error message

### DIFF
--- a/src/ctffind_runner.cpp
+++ b/src/ctffind_runner.cpp
@@ -460,6 +460,8 @@ void CtffindRunner::joinCtffindResults()
 
 		if (verb > 0 && imic % 60 == 0) progress_bar(imic);
 	}
+	if (MDctf.isEmpty())
+		REPORT_ERROR( (std::string) fn_ctffind_exe + " failed to estimate CTF parameters for any micrograph, exiting...");
 
     if (is_tomo)
     {

--- a/src/ctffind_runner.cpp
+++ b/src/ctffind_runner.cpp
@@ -694,7 +694,7 @@ void CtffindRunner::executeCtffind4(long int imic)
 
 	// Write script to run ctffind
 	fh << "#!/usr/bin/env " << fn_shell << std::endl;
-	fh << fn_ctffind_exe << ctffind4_options << " > " << fn_log << " << EOF"<<std::endl;
+	fh << "env LC_ALL=C " << fn_ctffind_exe << ctffind4_options << " > " << fn_log << " << EOF"<<std::endl;
 	// line 1: input image
 	if (do_movie_thon_rings)
 	{


### PR DESCRIPTION
Possible fix for issues like #1167? When CTFFIND fails to fit CTF parameters for all input micrographs (i.e. `MDctf` is empty) exit with an error rather than failing later. 