### PR TITLE
Ver5.0 HIP Fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -210,7 +210,7 @@ if(CUDA)
 elseif(HIP)
     # ------------------------------------------------------------------------------HIP--
     if (DEFINED ENV{ROCM_PATH})
-        include($ENV{ROCM_PATH}/hip/cmake/FindHIP.cmake)
+        include($ENV{ROCM_PATH}/lib/cmake/hip/FindHIP.cmake)
     elseif(DEFINED ENV{HIP_PATH})
         include($ENV{HIP_PATH}/cmake/FindHIP.cmake)
     elseif(EXISTS "${CMAKE_SOURCE_DIR}/cmake/FindHIP.cmake")

--- a/src/acc/hip/hip_fft.h
+++ b/src/acc/hip/hip_fft.h
@@ -7,7 +7,7 @@
 #include "src/acc/hip/hip_settings.h"
 #include "src/acc/hip/hip_mem_utils.h"
 #include <hip/hip_runtime.h>
-#include <hipfft.h>
+#include <hipfft/hipfft.h>
 
 #ifdef DEBUG_HIP
 #define HANDLE_HIPFFT_ERROR( err ) (HipfftHandleError( err, __FILE__, __LINE__ ))

--- a/src/acc/hip/hip_kernels/helper.h
+++ b/src/acc/hip/hip_kernels/helper.h
@@ -5,8 +5,8 @@
 #define HIP_HELPER_KERNELS_H_
 
 #include <hip/hip_runtime.h>
-#include <hiprand.h>
-#include <hiprand_kernel.h>
+#include <hiprand/hiprand.h>
+#include <hiprand/hiprand_kernel.h>
 #include <vector>
 #include <iostream>
 #include <fstream>

--- a/src/acc/hip/hip_kernels/helper.hip.cpp
+++ b/src/acc/hip/hip_kernels/helper.hip.cpp
@@ -7,8 +7,8 @@
 #include "src/acc/hip/hip_kernels/helper.h"
 #include "src/acc/hip/hip_settings.h"
 
-#include <hiprand.h>
-#include <hiprand_kernel.h>
+#include <hiprand/hiprand.h>
+#include <hiprand/hiprand_kernel.h>
 
 /// Needed explicit template instantiations
 template __global__ void hip_kernel_make_eulers_2D<true>(XFLOAT *,

--- a/src/acc/hip/hip_mem_utils.h
+++ b/src/acc/hip/hip_mem_utils.h
@@ -6,7 +6,7 @@
 
 #ifdef _HIP_ENABLED
 #include <hip/hip_runtime.h>
-#include <hiprand.h>
+#include <hiprand/hiprand.h>
 #include "src/acc/hip/hip_settings.h"
 #include "src/acc/hip/custom_allocator.h"
 #endif

--- a/src/acc/hip/hip_ml_optimiser.hip.cpp
+++ b/src/acc/hip/hip_ml_optimiser.hip.cpp
@@ -11,8 +11,8 @@
 #include <iostream>
 #include "src/ml_optimiser.h"
 #include <hip/hip_runtime.h>
-#include <hiprand.h>
-#include <hiprand_kernel.h>
+#include <hiprand/hiprand.h>
+#include <hiprand/hiprand_kernel.h>
 
 #include "src/acc/acc_ptr.h"
 #include "src/acc/acc_projector.h"

--- a/src/acc/hip/hip_settings.h
+++ b/src/acc/hip/hip_settings.h
@@ -15,7 +15,7 @@
 #include "src/macros.h"
 #include "src/error.h"
 
-#include <hiprand.h>
+#include <hiprand/hiprand.h>
 
 // Required compute capability
 #define HIP_CC_MAJOR 5

--- a/src/acc/hip/hip_utils_cub.h
+++ b/src/acc/hip/hip_utils_cub.h
@@ -39,14 +39,14 @@ if (ptr.getAllocator() == NULL)
 	max_pair.deviceAlloc();
 	size_t temp_storage_size = 0;
 
-	DEBUG_HANDLE_ERROR(hipcub::DeviceReduce::ArgMax( NULL, temp_storage_size, ~ptr, ~max_pair, ptr.getSize()));
+	DEBUG_HANDLE_ERROR(hipcub::DeviceReduce::ArgMax( NULL, temp_storage_size, ~ptr, ~max_pair, static_cast<int>(ptr.getSize())));
 
 	if(temp_storage_size==0)
 		temp_storage_size=1;
 
 	HipCustomAllocator::Alloc* alloc = ptr.getAllocator()->alloc(temp_storage_size);
 
-	DEBUG_HANDLE_ERROR(hipcub::DeviceReduce::ArgMax( alloc->getPtr(), temp_storage_size, ~ptr, ~max_pair, ptr.getSize(), ptr.getStream()));
+	DEBUG_HANDLE_ERROR(hipcub::DeviceReduce::ArgMax( alloc->getPtr(), temp_storage_size, ~ptr, ~max_pair, static_cast<int>(ptr.getSize()), ptr.getStream()));
 
 	max_pair.cpToHost();
 	ptr.streamSync();
@@ -75,14 +75,14 @@ if (ptr.getAllocator() == NULL)
 	min_pair.deviceAlloc();
 	size_t temp_storage_size = 0;
 
-	DEBUG_HANDLE_ERROR(hipcub::DeviceReduce::ArgMin( NULL, temp_storage_size, ~ptr, ~min_pair, ptr.getSize()));
+	DEBUG_HANDLE_ERROR(hipcub::DeviceReduce::ArgMin( NULL, temp_storage_size, ~ptr, ~min_pair, static_cast<int>(ptr.getSize())));
 
 	if(temp_storage_size==0)
 		temp_storage_size=1;
 
 	HipCustomAllocator::Alloc* alloc = ptr.getAllocator()->alloc(temp_storage_size);
 
-	DEBUG_HANDLE_ERROR(hipcub::DeviceReduce::ArgMin( alloc->getPtr(), temp_storage_size, ~ptr, ~min_pair, ptr.getSize(), ptr.getStream()));
+	DEBUG_HANDLE_ERROR(hipcub::DeviceReduce::ArgMin( alloc->getPtr(), temp_storage_size, ~ptr, ~min_pair, static_cast<int>(ptr.getSize()), ptr.getStream()));
 
 	min_pair.cpToHost();
 	ptr.streamSync();

--- a/src/apps/CMakeLists.txt
+++ b/src/apps/CMakeLists.txt
@@ -293,7 +293,7 @@ if (CUDA_FOUND)
 
 elseif (HIP_FOUND)
 	file(GLOB REL_HIP_SRC "${CMAKE_SOURCE_DIR}/src/acc/hip/*.cpp" "${CMAKE_SOURCE_DIR}/src/acc/hip/hip_kernels/*.cpp" )
-	hip_add_library(relion_gpu_util ${REL_HIP_SRC})
+	add_library(relion_gpu_util ${REL_HIP_SRC})
 
 	if (${CMAKE_BUILD_TYPE_LOWER} STREQUAL "profiling")
 		find_library(ROCM_TRACER_LIB NAMES roctx64 PATHS ${HIP_ROOT_DIR}/lib ${HIP_ROOT_DIR}/../lib REQUIRED)

--- a/src/projector.cpp
+++ b/src/projector.cpp
@@ -24,7 +24,7 @@
 #ifdef _CUDA_ENABLED
 	#include <cufft.h>
 #elif _HIP_ENABLED
-	#include <hipfft.h>
+	#include <hipfft/hipfft.h>
 #endif
 #if defined _CUDA_ENABLED || defined _HIP_ENABLED
 	#include <sys/types.h>


### PR DESCRIPTION
Minor updates to: 
* CMake config to correctly identify the HIP path
* `src/acc/hip/` files update paths of HIP lib headers (`'hipfft.h`, `hiprand.h`, `hipcub`)
These updates are required to ensure compatibility with newer ROCm > 5.7 and support on latest AMD Instinct GPUs.  