### PR TITLE
SYCL optimization for cache friendly data structure

### DIFF
--- a/src/acc/acc_projector.h
+++ b/src/acc/acc_projector.h
@@ -41,11 +41,11 @@ class AccProjector
 	#endif
 	size_t pitch2D;
 #else
-#ifndef ALTCPU
-	XFLOAT *mdlReal, *mdlImag;
-#else
+#ifdef ALTCPU
 	std::complex<XFLOAT> *mdlComplex;
 	int externalFree;
+#else
+	XFLOAT *mdlComplex;
 #endif
 #endif  // PROJECTOR_NO_TEXTURES
 
@@ -70,11 +70,8 @@ public:
 		mdlImag = 0;
 		pitch2D = 0;
 #else
-#ifndef ALTCPU
-		mdlReal = 0;
-		mdlImag = 0;
-#else
 		mdlComplex = 0;
+#ifdef ALTCPU
 		externalFree = 0;
 #endif
 #endif
@@ -88,10 +85,13 @@ public:
 			int inity, int initz,
 			int maxr, XFLOAT paddingFactor);
 
+#if defined(_CUDA_ENABLED) || defined(_HIP_ENABLED)
 	void initMdl(XFLOAT *real, XFLOAT *imag);
-	void initMdl(Complex *data);
+#endif
 #ifdef ALTCPU
 	void initMdl(std::complex<XFLOAT> *data);
+#else
+	void initMdl(Complex *data);
 #endif
 
 	void clear();

--- a/src/acc/acc_projectorkernel_impl.h
+++ b/src/acc/acc_projectorkernel_impl.h
@@ -22,34 +22,16 @@ public:
 		maxR, maxR2, maxR2_padded;
 	XFLOAT 	padding_factor;
 
+#if defined _CUDA_ENABLED || defined _HIP_ENABLED
 	PROJECTOR_PTR_TYPE mdlReal;
 	PROJECTOR_PTR_TYPE mdlImag;
-#ifndef ALTCPU
+#elif _SYCL_ENABLED
 	PROJECTOR_PTR_TYPE mdlComplex;
 #else
 	std::complex<XFLOAT> *mdlComplex;
 #endif
 
-	AccProjectorKernel(
-			int mdlX, int mdlY, int mdlZ,
-			int imgX, int imgY, int imgZ,
-			int mdlInitY, int mdlInitZ,
-			XFLOAT padding_factor,
-			int maxR,
-#ifndef ALTCPU
-			PROJECTOR_PTR_TYPE mdlComplex
-#else
-			std::complex<XFLOAT> *mdlComplex
-#endif
-			):
-			mdlX(mdlX), mdlXY(mdlX*mdlY), mdlZ(mdlZ),
-			imgX(imgX), imgY(imgY), imgZ(imgZ),
-			mdlInitY(mdlInitY), mdlInitZ(mdlInitZ),
-			padding_factor(padding_factor),
-			maxR(maxR), maxR2(maxR*maxR), maxR2_padded(maxR*maxR*padding_factor*padding_factor),
-			mdlComplex(mdlComplex)
-		{};
-
+#if defined _CUDA_ENABLED || defined _HIP_ENABLED
 	AccProjectorKernel(
 			int mdlX, int mdlY, int mdlZ,
 			int imgX, int imgY, int imgZ,
@@ -64,15 +46,28 @@ public:
 				padding_factor(padding_factor),
 				maxR(maxR), maxR2(maxR*maxR), maxR2_padded(maxR*maxR*padding_factor*padding_factor),
 				mdlReal(mdlReal), mdlImag(mdlImag)
-			{
-#ifdef ALTCPU
-				std::complex<XFLOAT> *pData = mdlComplex;
-				for(size_t i=0; i<(size_t)mdlX * (size_t)mdlY * (size_t)mdlZ; i++) {
-					std::complex<XFLOAT> arrayval(*mdlReal ++, *mdlImag ++);
-					pData[i] = arrayval;
-				}
+		{};
+#else
+	AccProjectorKernel(
+			int mdlX, int mdlY, int mdlZ,
+			int imgX, int imgY, int imgZ,
+			int mdlInitY, int mdlInitZ,
+			XFLOAT padding_factor,
+			int maxR,
+#if _SYCL_ENABLED
+			PROJECTOR_PTR_TYPE mdlComplex
+#else
+			std::complex<XFLOAT> *mdlComplex
 #endif
-			};
+			):
+			mdlX(mdlX), mdlXY(mdlX*mdlY), mdlZ(mdlZ),
+			imgX(imgX), imgY(imgY), imgZ(imgZ),
+			mdlInitY(mdlInitY), mdlInitZ(mdlInitZ),
+			padding_factor(padding_factor),
+			maxR(maxR), maxR2(maxR*maxR), maxR2_padded(maxR*maxR*padding_factor*padding_factor),
+			mdlComplex(mdlComplex)
+		{};
+#endif
 
 #if defined _CUDA_ENABLED || defined _HIP_ENABLED
 	__device__ __forceinline__
@@ -117,8 +112,8 @@ public:
 			real =   no_tex3D(mdlReal, xp, yp, zp, mdlX, mdlXY, mdlInitY, mdlInitZ);
 			imag = - no_tex3D(mdlImag, xp, yp, zp, mdlX, mdlXY, mdlInitY, mdlInitZ);
 #elif _SYCL_ENABLED
-			real =   syclKernels::no_tex3D(mdlReal, xp, yp, zp, mdlX, mdlXY, mdlInitY, mdlInitZ);
-			imag = - syclKernels::no_tex3D(mdlImag, xp, yp, zp, mdlX, mdlXY, mdlInitY, mdlInitZ);
+			syclKernels::no_tex3D(mdlComplex, real, imag, xp, yp, zp, mdlX, mdlXY, mdlInitY, mdlInitZ);
+			imag = -imag;
 #else
 			CpuKernels::complex3D(mdlComplex, real, imag, xp, yp, zp, mdlX, mdlXY, mdlInitY, mdlInitZ);
 #endif
@@ -197,8 +192,7 @@ public:
 			real = no_tex3D(mdlReal, xp, yp, zp, mdlX, mdlXY, mdlInitY, mdlInitZ);
 			imag = no_tex3D(mdlImag, xp, yp, zp, mdlX, mdlXY, mdlInitY, mdlInitZ);
 	#elif _SYCL_ENABLED
-			real = syclKernels::no_tex3D(mdlReal, xp, yp, zp, mdlX, mdlXY, mdlInitY, mdlInitZ);
-			imag = syclKernels::no_tex3D(mdlImag, xp, yp, zp, mdlX, mdlXY, mdlInitY, mdlInitZ);
+			syclKernels::no_tex3D(mdlComplex, real, imag, xp, yp, zp, mdlX, mdlXY, mdlInitY, mdlInitZ);
 	#else
 			CpuKernels::complex3D(mdlComplex, real, imag, xp, yp, zp, mdlX, mdlXY, mdlInitY, mdlInitZ);
 	#endif
@@ -270,8 +264,7 @@ __device__ __forceinline__
 			real = no_tex2D(mdlReal, xp, yp, mdlX, mdlInitY);
 			imag = no_tex2D(mdlImag, xp, yp, mdlX, mdlInitY);
 	#elif _SYCL_ENABLED
-			real = syclKernels::no_tex2D(mdlReal, xp, yp, mdlX, mdlInitY);
-			imag = syclKernels::no_tex2D(mdlImag, xp, yp, mdlX, mdlInitY);
+			syclKernels::no_tex2D(mdlComplex, real, imag, xp, yp, mdlX, mdlInitY);
 	#else
 			CpuKernels::complex2D(mdlComplex, real, imag, xp, yp, mdlX, mdlInitY);
 	#endif
@@ -319,12 +312,7 @@ __device__ __forceinline__
 					*p.mdlReal,
 					*p.mdlImag
 #else
-#ifndef ALTCPU
-					p.mdlReal,
-					p.mdlImag
-#else
 					p.mdlComplex
-#endif
 #endif
 				);
 		return k;

--- a/src/acc/sycl/sycl_kernels/sycl_utils.h
+++ b/src/acc/sycl/sycl_kernels/sycl_utils.h
@@ -27,160 +27,84 @@ int ceilfracf(T1 a, T2 b)
 	return static_cast<int>(a/b + 1);
 }
 
-__attribute__((always_inline))
-static inline
-XFLOAT no_tex2D(XFLOAT *mdl, XFLOAT xp, XFLOAT yp, int mdlX, int mdlInitY)
-{
-	int x0 = sycl::floor(xp);
-	XFLOAT fx = xp - x0;
-
-	int y0 = sycl::floor(yp);
-	XFLOAT fy = yp - y0;
-	y0 -= mdlInitY;
-
-	int offset1 = (y0 * mdlX + x0);
-	int offset2 = offset1 + 1;
-	int offset3 = offset1 + mdlX;
-	int offset4 = offset1 + mdlX + 1;
-	//-----------------------------
-	XFLOAT d00 = mdl[offset1];
-	XFLOAT d01 = mdl[offset2];
-	XFLOAT d10 = mdl[offset3];
-	XFLOAT d11 = mdl[offset4];
-	//-----------------------------
-	XFLOAT dx0 = d00 + (d01 - d00)*fx;
-	XFLOAT dx1 = d10 + (d11 - d10)*fx;
-	//-----------------------------
-	return dx0 + (dx1 - dx0)*fy;
-}
-
 // 2D linear interpolation for complex data that interleaves real and
 // imaginary data, rather than storing them in a separate array
 __attribute__((always_inline))
-inline
-static void complex2D(std::complex<XFLOAT> *mdlComplex, XFLOAT &real, XFLOAT &imag,
-				XFLOAT xp, XFLOAT yp, int mdlX, int mdlInitY)
+static inline
+void no_tex2D(XFLOAT *mdl, XFLOAT &real, XFLOAT &imag, XFLOAT xp, XFLOAT yp, int mdlX, int mdlInitY)
 {
-	int x0 = sycl::floor(xp);
-	XFLOAT fx = xp - x0;
+	const int x0 = sycl::floor(xp);
+	const XFLOAT fx = xp - x0;
 
-	int y0 = sycl::floor(yp);
-	XFLOAT fy = yp - y0;
-	y0 -= mdlInitY;
+	const int y0 = sycl::floor(yp);
+	const XFLOAT fy = yp - y0;
 
-	int offset1 = (y0 * mdlX + x0);
-	int offset2 = offset1 + 1;
-	int offset3 = offset1 + mdlX;
-	int offset4 = offset1 + mdlX + 1;
+	const int offset1 = 2 * ((y0-mdlInitY)*mdlX + x0);
+	const int offset2 = offset1 + 2;
+	const int offset3 = offset1 + 2*mdlX;
+	const int offset4 = offset3 + 2;
+
 	//-----------------------------
-	XFLOAT d00[2] {mdlComplex[offset1].real(), mdlComplex[offset1].imag()};
-	XFLOAT d01[2] {mdlComplex[offset2].real(), mdlComplex[offset2].imag()};
-	XFLOAT d10[2] {mdlComplex[offset3].real(), mdlComplex[offset3].imag()};
-	XFLOAT d11[2] {mdlComplex[offset4].real(), mdlComplex[offset4].imag()};
+	const XFLOAT d00[2] = { mdl[offset1], mdl[offset1+1] };
+	const XFLOAT d01[2] = { mdl[offset2], mdl[offset2+1] };
+	const XFLOAT d10[2] = { mdl[offset3], mdl[offset3+1] };
+	const XFLOAT d11[2] = { mdl[offset4], mdl[offset4+1] };
 	//-----------------------------
-	XFLOAT dx0[2] {d00[0] + (d01[0] - d00[0]) * fx, d00[1] + (d01[1] - d00[1]) * fx};
-	XFLOAT dx1[2] {d10[0] + (d11[0] - d10[0]) * fx, d10[1] + (d11[1] - d10[1]) * fx};
-	//-----------------------------	
+	const XFLOAT dx0[2] = { d00[0] + (d01[0] - d00[0])*fx, d00[1] + (d01[1] - d00[1])*fx };
+	const XFLOAT dx1[2] = { d10[0] + (d11[0] - d10[0])*fx, d10[1] + (d11[1] - d10[1])*fx };
+	//-----------------------------
 	real = dx0[0] + (dx1[0] - dx0[0])*fy;
 	imag = dx0[1] + (dx1[1] - dx0[1])*fy;
-}
-
-__attribute__((always_inline))
-static inline
-XFLOAT no_tex3D(
-				XFLOAT *mdl, 
-				XFLOAT xp, XFLOAT yp, XFLOAT zp, 
-				int mdlX, int mdlXY, int mdlInitY, int mdlInitZ)
-{
-	int x0 = sycl::floor(xp);
-	XFLOAT fx = xp - x0;
-
-	int y0 = sycl::floor(yp);
-	XFLOAT fy = yp - y0;
-	y0 -= mdlInitY;
-
-	int z0 = sycl::floor(zp);
-	XFLOAT fz = zp - z0;
-	z0 -= mdlInitZ;
-
-	int offset1 = (z0*mdlXY+y0*mdlX+x0);
-	int offset2 = offset1 + 1;
-	int offset3 = offset1 + mdlX;
-	int offset4 = offset1 + mdlX + 1;
-	int offset5 = offset1 + mdlXY;
-	int offset6 = offset1 + mdlXY + 1;
-	int offset7 = offset1 + mdlX + mdlXY;
-	int offset8 = offset1 + mdlX + mdlXY + 1;
-	//-----------------------------
-	XFLOAT d000 = mdl[offset1];
-	XFLOAT d001 = mdl[offset2];
-	XFLOAT d010 = mdl[offset3];
-	XFLOAT d011 = mdl[offset4];
-	XFLOAT d100 = mdl[offset5];
-	XFLOAT d101 = mdl[offset6];
-	XFLOAT d110 = mdl[offset7];
-	XFLOAT d111 = mdl[offset8];
-	//-----------------------------
-	XFLOAT dx00 = d000 + (d001 - d000)*fx;
-	XFLOAT dx01 = d100 + (d101 - d100)*fx;
-	XFLOAT dx10 = d010 + (d011 - d010)*fx;
-	XFLOAT dx11 = d110 + (d111 - d110)*fx;
-	//-----------------------------
-	XFLOAT dxy0 = dx00 + (dx10 - dx00)*fy;
-	XFLOAT dxy1 = dx01 + (dx11 - dx01)*fy;
-	//-----------------------------
-	return dxy0 + (dxy1 - dxy0)*fz;
 }
 
 // 3D linear interpolation for complex data that interleaves real and
 // imaginary data, rather than storing them in a separate array
 __attribute__((always_inline))
-inline
-static void complex3D(
-				std::complex<XFLOAT> *mdlComplex, 
-				XFLOAT &real, XFLOAT &imag,
-				XFLOAT xp, XFLOAT yp, XFLOAT zp, int mdlX, int mdlXY, int mdlInitY, int mdlInitZ
-		)
+static inline
+void no_tex3D(
+				XFLOAT *mdl, XFLOAT &real, XFLOAT &imag,
+				XFLOAT xp, XFLOAT yp, XFLOAT zp,
+				int mdlX, int mdlXY, int mdlInitY, int mdlInitZ)
 {
-	int x0 = sycl::floor(xp);
-	XFLOAT fx = xp - x0;
+	const int x0 = sycl::floor(xp);
+	const XFLOAT fx = xp - x0;
 
-	int y0 = sycl::floor(yp);
-	XFLOAT fy = yp - y0;
-	y0 -= mdlInitY;
+	const int y0 = sycl::floor(yp);
+	const XFLOAT fy = yp - y0;
 
-	int z0 = sycl::floor(zp);
-	XFLOAT fz = zp - z0;
-	z0 -= mdlInitZ;
+	const int z0 = sycl::floor(zp);
+	const XFLOAT fz = zp - z0;
 
-	int offset1 = (z0*mdlXY+y0*mdlX+x0);
-	int offset2 = offset1 + 1;
-	int offset3 = offset1 + mdlX;
-	int offset4 = offset1 + mdlX + 1;
-	int offset5 = offset1 + mdlXY;
-	int offset6 = offset1 + mdlXY + 1;
-	int offset7 = offset1 + mdlX + mdlXY;
-	int offset8 = offset1 + mdlX + mdlXY + 1;
+	const int offset1 = 2*((z0-mdlInitZ)*mdlXY + (y0-mdlInitY)*mdlX + x0);
+	const int offset2 = offset1 + 2;
+	const int offset3 = offset1 + 2*mdlX;
+	const int offset4 = offset3 + 2;
+	const int offset5 = offset1 + 2*mdlXY;
+	const int offset6 = offset2 + 2*mdlXY;
+	const int offset7 = offset3 + 2*mdlXY;
+	const int offset8 = offset4 + 2*mdlXY;
 
-	XFLOAT d000[2] {mdlComplex[offset1].real(), mdlComplex[offset1].imag()};
-	XFLOAT d001[2] {mdlComplex[offset2].real(), mdlComplex[offset2].imag()};
-	XFLOAT d010[2] {mdlComplex[offset3].real(), mdlComplex[offset3].imag()};
-	XFLOAT d011[2] {mdlComplex[offset4].real(), mdlComplex[offset4].imag()};
-	XFLOAT d100[2] {mdlComplex[offset5].real(), mdlComplex[offset5].imag()};
-	XFLOAT d101[2] {mdlComplex[offset6].real(), mdlComplex[offset6].imag()};
-	XFLOAT d110[2] {mdlComplex[offset7].real(), mdlComplex[offset7].imag()};
-	XFLOAT d111[2] {mdlComplex[offset8].real(), mdlComplex[offset8].imag()};
-	//-----------------------------
-	XFLOAT dx00[2] {d000[0] + (d001[0] - d000[0])*fx, d000[1] + (d001[1] - d000[1])*fx};
-	XFLOAT dx01[2] {d100[0] + (d101[0] - d100[0])*fx, d100[1] + (d101[1] - d100[1])*fx};
-	XFLOAT dx10[2] {d010[0] + (d011[0] - d010[0])*fx, d010[1] + (d011[1] - d010[1])*fx};
-	XFLOAT dx11[2] {d110[0] + (d111[0] - d110[0])*fx, d110[1] + (d111[1] - d110[1])*fx};
-	//-----------------------------
-	XFLOAT dxy0[2] {dx00[0] + (dx10[0] - dx00[0])*fy, dx00[1] + (dx10[1] - dx00[1])*fy};
-	XFLOAT dxy1[2] {dx01[0] + (dx11[0] - dx01[0])*fy, dx01[1] + (dx11[1] - dx01[1])*fy};
-	//-----------------------------
+	const XFLOAT d000[2] = { mdl[offset1], mdl[offset1+1] };
+	const XFLOAT d001[2] = { mdl[offset2], mdl[offset2+1] };
+	const XFLOAT d010[2] = { mdl[offset3], mdl[offset3+1] };
+	const XFLOAT d011[2] = { mdl[offset4], mdl[offset4+1] };
+	const XFLOAT d100[2] = { mdl[offset5], mdl[offset5+1] };
+	const XFLOAT d101[2] = { mdl[offset6], mdl[offset6+1] };
+	const XFLOAT d110[2] = { mdl[offset7], mdl[offset7+1] };
+	const XFLOAT d111[2] = { mdl[offset8], mdl[offset8+1] };
+
+	const XFLOAT dx00[2] = { d000[0] + (d001[0] - d000[0])*fx, d000[1] + (d001[1] - d000[1])*fx };
+	const XFLOAT dx10[2] = { d010[0] + (d011[0] - d010[0])*fx, d010[1] + (d011[1] - d010[1])*fx };
+	const XFLOAT dx01[2] = { d100[0] + (d101[0] - d100[0])*fx, d100[1] + (d101[1] - d100[1])*fx };
+	const XFLOAT dx11[2] = { d110[0] + (d111[0] - d110[0])*fx, d110[1] + (d111[1] - d110[1])*fx };
+
+	const XFLOAT dxy0[2] = {  dx00[0] + (dx10[0] - dx00[0])*fy,
+								dx00[1] + (dx10[1] - dx00[1])*fy };
+	const XFLOAT dxy1[2] = {  dx01[0] + (dx11[0] - dx01[0])*fy,
+								dx01[1] + (dx11[1] - dx01[1])*fy };
+
 	real = dxy0[0] + (dxy1[0] - dxy0[0])*fz;
-	imag = dxy0[1] + (dxy1[1] - dxy0[1])*fz;	
+	imag = dxy0[1] + (dxy1[1] - dxy0[1])*fz;
 }
 
 // From https://en.cppreference.com/w/cpp/types/numeric_limits/epsilon


### PR DESCRIPTION
- Merge mdlReal and mdlImag to a single array with doubled size for cache efficient access
- Make required change and some cleanups for this mdlReal/mdlImag to mdlComplex in the required files in src/acc/ directory
- Change no_tex2D and no_tex3D to this mdlReal and mdlImag merging optimization (src/acc/sycl/sycl_kernels/sycl_utils.h)
- Remove unused complex2D and complex3D
- Change the location of group_barrier to remove unnecessary expensive barrier instruction

Compiling and running are checked for legacy, CPU, and CUDA acceleration code path.