### PR TITLE
bugfix: reconstruct particle contrast inversion

### DIFF
--- a/src/jaz/tomography/programs/reconstruct_particle.cpp
+++ b/src/jaz/tomography/programs/reconstruct_particle.cpp
@@ -393,12 +393,10 @@ void ReconstructParticleProgram::processTomograms(
 						}
 					}
 				}
-
-                // If we're not doing CTF premultiplication, we may still want to invert the contrast
-                if (!do_ctf) particleStack[th] *= sign;
-
 			}
 
+			// If we're not doing CTF premultiplication, we may still want to invert the contrast
+			if (!do_ctf) particleStack[th] *= sign;
 
 			if (aberrationsCache.hasAntisymmetrical)
 			{


### PR DESCRIPTION
Contrast inversion of the entire particle stack should happen only one time per particle, not per every frame. 