### PR TITLE
progress_bar: suppress animation when stdout is not a TTY

### DIFF
--- a/src/time.cpp
+++ b/src/time.cpp
@@ -112,6 +112,9 @@ void init_progress_bar(long total)
 // routine must be in ascending order, ie, 0, 1, 2, ... No. elements
 void progress_bar(long rlen)
 {
+	if (!isatty(fileno(stdout)))
+		return;
+
 	static time_t startt, prevt;
 	time_t currt;
 	static long totlen;


### PR DESCRIPTION
## Summary

- `progress_bar()` in `src/time.cpp` uses `\r` to animate in-place on a real terminal, but when stdout is captured (AWS Batch container, file redirect), every animation frame is a separate line — flooding logs with hundreds of `~~(,_,">` / `[oo]` lines per progress event
- Class2D, Class3D, Refine3D jobs are worst offenders (many EM iterations × multiple progress events per iteration)
- Fix: `isatty(fileno(stdout))` early return — suppresses all animation output when stdout is not a TTY; interactive terminal users unaffected

## Test plan

- [ ] Run Class2D/Class3D/Refine3D job via CryoCloud and verify CloudWatch logs have zero lines matching `~~(,_,">`
- [ ] Run RELION interactively in a terminal and verify animation still appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)