### PR TITLE
Preserve IMOD final tilt angles in YTilt

### DIFF
--- a/src/align_tiltseries_runner.cpp
+++ b/src/align_tiltseries_runner.cpp
@@ -658,8 +658,8 @@ bool AlignTiltseriesRunner::readIMODResults(long idx_tomo, std::string &error_me
     std::string line;
     std::vector<std::string> words;
 
-    // 1. Get tiltangle_offset from the align.log file
-    RFLOAT tiltangle_offset = 0., mean_error = 0., stddev_error = 0., leaveout_error = 0.;
+    // 1. Get alignment diagnostics from the align.log file
+    RFLOAT mean_error = 0., stddev_error = 0., leaveout_error = 0.;
     std::ifstream in0(fn_align.data(), std::ios_base::in);
     if (in0.fail())
     {
@@ -670,13 +670,7 @@ bool AlignTiltseriesRunner::readIMODResults(long idx_tomo, std::string &error_me
     in0.seekg(0);
     while (getline(in0, line, '\n'))
     {
-        if (line.find("AngleOffset = ") != std::string::npos)
-        {
-            tokenize(line, words);
-            if (words.size() < 3) REPORT_ERROR("ERROR: fewer than 3 columns on this line from align.log file: " + line);
-            tiltangle_offset = textToFloat(words[2]);
-        }
-        else if (line.find("Residual error mean and sd:") != std::string::npos)
+        if (line.find("Residual error mean and sd:") != std::string::npos)
         {
             tokenize(line, words);
             if (words.size() < 7) REPORT_ERROR("ERROR: fewer than 7 columns on this line from align.log file: " + line);
@@ -737,7 +731,7 @@ bool AlignTiltseriesRunner::readIMODResults(long idx_tomo, std::string &error_me
     if (f != fc) REPORT_ERROR("ERROR: found " + integerToString(f) + " entries in xf file " + fn_xf + ", but expected " +
                                                  integerToString(fc) + " entries...");
 
-    // 3. Get ytilt angles straight from the .tlt file (and apply tiltangle_offset)
+    // 3. Get ytilt angles straight from IMOD's final .tlt file.
     std::ifstream in2(fn_tlt.data(), std::ios_base::in);
     if (in2.fail())
     {
@@ -752,8 +746,9 @@ bool AlignTiltseriesRunner::readIMODResults(long idx_tomo, std::string &error_me
         tokenize(line, words);
         if (words.size() != 1) REPORT_ERROR("ERROR: did not find 1 column in tlt file: " + fn_tlt);
         tomogramSet.tomogramTables[idx_tomo].setValue(EMDL_TOMO_XTILT, 0., f);
-        // Subtract tilt_angle_offset
-        tomogramSet.tomogramTables[idx_tomo].setValue(EMDL_TOMO_YTILT, textToFloat(words[0]) - tiltangle_offset, f);
+        // The .tlt file is IMOD's final OutputTiltFile. If tiltalign estimated
+        // an AngleOffset, those final angles already include it.
+        tomogramSet.tomogramTables[idx_tomo].setValue(EMDL_TOMO_YTILT, textToFloat(words[0]), f);
 
         f++;
     }

--- a/src/tomography_python_programs/align_tilt_series/imod/_utils.py
+++ b/src/tomography_python_programs/align_tilt_series/imod/_utils.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from yet_another_imod_wrapper.utils.etomo import \
-    EtomoOutput, get_tilt_angle_offset, get_input_tilt_axis_rotation_angle
+    EtomoOutput, get_input_tilt_axis_rotation_angle
 from yet_another_imod_wrapper.utils.xf import XF
 from yet_another_imod_wrapper.utils.io import read_tlt
 
@@ -17,16 +17,19 @@ def get_specimen_shifts(etomo_output: EtomoOutput) -> np.ndarray:
 
 
 def get_xyz_extrinsic_euler_angles(etomo_output: EtomoOutput) -> np.ndarray:
-    """Get XYZ extrinsic Euler angles which rotate the specimen from etomo."""
+    """Get XYZ extrinsic Euler angles which rotate the specimen from etomo.
+
+    IMOD's .tlt file is the final OutputTiltFile used by IMOD tilt for
+    reconstruction. If tiltalign estimated an AngleOffset, those final angles
+    already include it. Store them directly in rlnTomoYTilt so RELION's
+    projection matrices match the IMOD reconstruction geometry.
+    """
     in_plane_rotation = get_input_tilt_axis_rotation_angle(
         etomo_output.align_log_file
     )
     xf = XF.from_file(etomo_output.xf_file, initial_tilt_axis_rotation_angle=in_plane_rotation)
     tilt_angles = read_tlt(etomo_output.tlt_file)
     n_images = len(tilt_angles)
-    tilt_angle_offset = get_tilt_angle_offset(etomo_output.align_log_file)
-    if tilt_angle_offset is not None:
-        tilt_angles -= tilt_angle_offset
     euler_angles = np.empty(shape=(n_images, 3))
     euler_angles[:, 0] = 0
     euler_angles[:, 1] = tilt_angles


### PR DESCRIPTION
## Summary
- keep IMOD final `.tlt` angles in `_rlnTomoYTilt` instead of subtracting `AngleOffset`
- make the C++ align_tiltseries runner and Python IMOD helper consistent
- document that `.tlt` is IMOD's final OutputTiltFile used for reconstruction geometry

## Rationale
When IMOD `tiltalign` estimates `AngleOffset`, the final `.tlt` file already includes that offset and IMOD `tilt` reconstructs from those corrected angles. Subtracting `AngleOffset` while writing `_rlnTomoYTilt` reverts the STAR metadata to nominal stage tilts, making RELION projection matrices inconsistent with the IMOD reconstruction geometry. This matches the symptom reported in #1141.

## CTF / downstream extraction
This PR intentionally does not rewrite existing `_rlnCtfScalefactor` values during alignment. RELION native tomogram reconstruction already initializes `_rlnCtfScalefactor = cos(_rlnTomoYTilt)` when the column is absent, so preserving the final IMOD angles keeps the default CTF scale consistent with the projection geometry.

If `_rlnCtfScalefactor` is already present, it may have been written by RELION CTF refinement as a signal/ice-thickness scale. Overwriting it at alignment-import time would be unsafe.

## Tests
- `git diff --check`
- `python -m py_compile src/tomography_python_programs/align_tilt_series/imod/_utils.py`