### PR TITLE
tomo: respect _rlnTomoVisibleFrames in particle reconstruction

### DIFF
--- a/src/jaz/tomography/programs/reconstruct_particle.cpp
+++ b/src/jaz/tomography/programs/reconstruct_particle.cpp
@@ -198,6 +198,8 @@ void ReconstructParticleProgram::processTomograms(
 	const int s = dataImgFS[0].ydim;
 	const int sh = s/2 + 1;
 	const int tc = tomoIndices.size();
+	const bool has_explicit_visible_frames =
+		particleSet.partTable.containsLabel(EMDL_TOMO_VISIBLE_FRAMES);
 
     if (verbosity > 0 && !per_tomogram_progress)
 	{
@@ -343,7 +345,38 @@ void ReconstructParticleProgram::processTomograms(
 						part_id, fc, tomogram.centre, tomogram.optics.pixelSize);
 			std::vector<d4Matrix> projCut(fc), projPart(fc);
 
-			const std::vector<bool> isVisible = tomogram.determineVisiblity(traj, s/2.0);
+			std::vector<bool> isVisible = tomogram.determineVisiblity(traj, s/2.0);
+
+			// Intersect geometric visibility with the explicit per-particle
+			// _rlnTomoVisibleFrames mask that subtomo writes when --max_dose
+			// (or any frame filter) was used at extraction. Without this,
+			// reconstruction silently includes frames that were excluded
+			// from the 2D stacks and from Refine3D alignment, so the
+			// per-particle CTF + dose-weight math uses a different frame
+			// set than the data on disk. exp_model.cpp's "Add only the
+			// visible images for this particle" loop is the authoritative
+			// pattern that this matches.
+			if (has_explicit_visible_frames)
+			{
+				const std::vector<int> explicitVisible =
+					particleSet.getVisibleFrames(part_id);
+
+				if ((int)explicitVisible.size() != fc)
+				{
+					REPORT_ERROR_STR(
+						"reconstruct_particle: bad "
+						<< EMDL::label2Str(EMDL_TOMO_VISIBLE_FRAMES)
+						<< " length for particle "
+						<< particleSet.getName(part_id)
+						<< "; expected " << fc
+						<< " frames, found " << explicitVisible.size());
+				}
+
+				for (int f = 0; f < fc; f++)
+				{
+					isVisible[f] = isVisible[f] && (explicitVisible[f] != 0);
+				}
+			}
 
 			const bool circle_crop = do_circle_crop;
 


### PR DESCRIPTION
## Summary

`reconstruct_particle.cpp::processTomograms` determines per-tilt visibility for each particle purely from `Tomogram::determineVisiblity(traj, s/2.0)` (geometric center-in-frame test). This silently ignores the explicit per-particle `_rlnTomoVisibleFrames` mask that `subtomo` writes into `particles.star` when `--max_dose` (or any frame filter) is set at extraction.

`ml_optimiser` (Refine3D / Class3D) already respects the mask — see [`src/exp_model.cpp` "Add only the visible images for this particle"](https://github.com/3dem/relion/blob/ver5.1/src/exp_model.cpp). So in a `--stack2d --max_dose` pipeline, Extract and Refine3D use one frame set, but standalone `relion_tomo_reconstruct_particle` uses a different (geometric-only) frame set.

This patch makes reconstruction match the same authoritative pattern: when `EMDL_TOMO_VISIBLE_FRAMES` is present on the particle table, intersect geometric visibility with the explicit mask.

## Rationale context

When `--max_dose` filtered the 2D stacks down to e.g. 16.5 visible frames per particle on average, reconstruction was using ~39.2 frames per particle (all geometrically visible tilts including dose-excluded ones). The per-particle CTF + dose-weight math at reconstruction time therefore used a different frame set than:

1. The frames baked into the `*_stack2d.mrcs` data on disk
2. The frames Refine3D used for the alignment that we're reconstructing from

## Compatibility

- Backwards-compatible: behaviour unchanged for inputs without `_rlnTomoVisibleFrames`. The `has_explicit_visible_frames` check only engages the new path when the column is present.
- No new dependencies; uses the existing `ParticleSet::getVisibleFrames` helper that `exp_model.cpp` already calls.
- Hard-errors with a clear message if the column exists but has an unexpected length for the tomogram.

## Tests

- On the project used for diagnosis (4 tomograms, ~6200 2D-stack particles, `--max_dose 50`): post-fix `<isVisible>` per particle drops from 39.2 to 16.5, matching the `_rlnTomoVisibleFrames` mask that Extract wrote.
