### PR TITLE
bugfix: reuse explicit GPU IDs cyclically across MPI ranks

### DIFF
--- a/src/align_tiltseries_runner.cpp
+++ b/src/align_tiltseries_runner.cpp
@@ -563,13 +563,11 @@ void AlignTiltseriesRunner::executeAreTomo(long idx_tomo, int rank)
 
     if (gpu_ids.length() > 0)
     {
-        if (rank >= allThreadIDs.size())
-            REPORT_ERROR("ERROR: not enough MPI nodes specified for the GPU IDs.");
-
         command += " -Gpu " ;
-        for (int igpu = 0; igpu < allThreadIDs[rank].size(); igpu++)
+        const std::vector<std::string> &rankThreadIDs = getDeviceIDsForRank(allThreadIDs, rank);
+        for (int igpu = 0; igpu < rankThreadIDs.size(); igpu++)
         {
-            command += allThreadIDs[rank][igpu] + " ";
+            command += rankThreadIDs[igpu] + " ";
         }
     }
 

--- a/src/align_tiltseries_runner.h
+++ b/src/align_tiltseries_runner.h
@@ -27,6 +27,7 @@
 #include  <stdlib.h>
 #include  <unistd.h>
 #include  <stdio.h>
+#include "src/args.h"
 #include <src/metadata_table.h>
 #include <src/image.h>
 #include <src/time.h>

--- a/src/amyloid_finder.cpp
+++ b/src/amyloid_finder.cpp
@@ -244,7 +244,7 @@ void AmyloidFinder::deviceInitialise()
 	untangleDeviceIDs(gpu_ids, allThreadIDs);
 
 	// Sequential initialisation of GPUs on all ranks
-	if (!std::isdigit(*gpu_ids.begin()))
+	if (!hasExplicitDeviceIDs(gpu_ids))
 		device_id = 0;
 	else
 		device_id = textToInteger((allThreadIDs[0][0]).c_str());

--- a/src/amyloid_finder_mpi.cpp
+++ b/src/amyloid_finder_mpi.cpp
@@ -53,10 +53,10 @@ void AmyloidFinderMpi::deviceInitialise()
 	untangleDeviceIDs(gpu_ids, allThreadIDs);
 
 	// Sequential initialisation of GPUs on all ranks
-	if (!std::isdigit(*gpu_ids.begin()))
+	if (!hasExplicitDeviceIDs(gpu_ids))
 		device_id = node->rank%devCount;
 	else
-		device_id = textToInteger((allThreadIDs[node->rank][0]).c_str());
+		device_id = textToInteger(getDeviceIDsForRank(allThreadIDs, node->rank)[0].c_str());
 
 	for (int follower = 0; follower < node->size; follower++)
 	{

--- a/src/args.cpp
+++ b/src/args.cpp
@@ -46,6 +46,7 @@
 #include "src/gcc_version.h"
 #include "src/matrix1d.h"
 #include <algorithm>
+#include <cctype>
 
 // Get parameters from the command line ====================================
 std::string getParameter(int argc, char **argv, const std::string param, const std::string option)
@@ -472,3 +473,30 @@ void untangleDeviceIDs(std::string &tangled, std::vector < std::vector < std::st
 #endif
 }
 
+bool hasExplicitDeviceIDs(const std::string &gpu_ids)
+{
+	return gpu_ids.size() > 0 && std::isdigit(static_cast<unsigned char>(gpu_ids[0]));
+}
+
+const std::vector<std::string>& getDeviceIDsForRank(
+	const std::vector < std::vector < std::string > > &allThreadIDs,
+	int rank)
+{
+	if (rank < 0)
+		REPORT_ERROR("Negative MPI rank requested for GPU ID assignment.");
+
+	if (allThreadIDs.size() == 0)
+		REPORT_ERROR("No GPU IDs parsed from --gpu.");
+
+	const std::vector<std::string> &rankThreadIDs = allThreadIDs[rank % allThreadIDs.size()];
+	if (rankThreadIDs.size() == 0)
+		REPORT_ERROR("No GPU IDs parsed for MPI rank from --gpu.");
+
+	for (int i = 0; i < rankThreadIDs.size(); i++)
+	{
+		if (rankThreadIDs[i] == "")
+			REPORT_ERROR("Empty GPU ID parsed from --gpu.");
+	}
+
+	return rankThreadIDs;
+}

--- a/src/args.h
+++ b/src/args.h
@@ -218,4 +218,14 @@ public:
  */
 void untangleDeviceIDs(std::string &tangled, std::vector < std::vector < std::string > > &untangled);
 
+bool hasExplicitDeviceIDs(const std::string &gpu_ids);
+
+/*
+ * Returns the device IDs for an MPI rank. If fewer rank-specific GPU ID groups
+ * are provided than MPI ranks, the groups are reused cyclically.
+ */
+const std::vector<std::string>& getDeviceIDsForRank(
+	const std::vector < std::vector < std::string > > &allThreadIDs,
+	int rank);
+
 #endif

--- a/src/autopicker.cpp
+++ b/src/autopicker.cpp
@@ -967,7 +967,7 @@ void AutoPicker::deviceInitialise()
 	untangleDeviceIDs(gpu_ids, allThreadIDs);
 
 	// Sequential initialisation of GPUs on all ranks
-	if (!std::isdigit(*gpu_ids.begin()))
+	if (!hasExplicitDeviceIDs(gpu_ids))
 		device_id = 0;
 	else
 		device_id = textToInteger((allThreadIDs[0][0]).c_str());

--- a/src/autopicker_mpi.cpp
+++ b/src/autopicker_mpi.cpp
@@ -54,10 +54,10 @@ void AutoPickerMpi::deviceInitialise()
 	untangleDeviceIDs(gpu_ids, allThreadIDs);
 
 	// Sequential initialisation of GPUs on all ranks
-	if (!std::isdigit(*gpu_ids.begin()))
+	if (!hasExplicitDeviceIDs(gpu_ids))
 		device_id = node->rank%devCount;
 	else
-		device_id = textToInteger((allThreadIDs[node->rank][0]).c_str());
+		device_id = textToInteger(getDeviceIDsForRank(allThreadIDs, node->rank)[0].c_str());
 
 	for (int follower = 0; follower < node->size; follower++)
 	{

--- a/src/ml_optimiser.cpp
+++ b/src/ml_optimiser.cpp
@@ -1608,7 +1608,7 @@ void MlOptimiser::initialise()
         // Sequential initialisation of GPUs on all ranks
         bool fullAutomaticMapping(true);
         bool semiAutomaticMapping(true);
-        if (allThreadIDs[0].size()==0 || (!std::isdigit(*gpu_ids.begin())) )
+        if (allThreadIDs[0].size()==0 || (!hasExplicitDeviceIDs(gpu_ids)) )
             std::cout << "gpu-ids not specified, threads will automatically be mapped to devices (incrementally)."<< std::endl;
         else
         {
@@ -1714,7 +1714,7 @@ void MlOptimiser::initialise()
 
 		bool fullAutomaticMapping;
 		bool semiAutomaticMapping;
-		if (allThreadIDs[0].size()==0 || ! std::isdigit(*gpu_ids.begin()) )
+		if (allThreadIDs[0].size()==0 || !hasExplicitDeviceIDs(gpu_ids) )
 		{
 			fullAutomaticMapping = true;
 			semiAutomaticMapping = true;

--- a/src/ml_optimiser_mpi.cpp
+++ b/src/ml_optimiser_mpi.cpp
@@ -241,7 +241,7 @@ void MlOptimiserMpi::initialise()
 				fullAutomaticMapping = true;
 				semiAutomaticMapping = true; // possible to set fully manual for specific ranks
 
-				if ((allThreadIDs.size()<rank) || allThreadIDs[0].size()==0 || (!std::isdigit(*gpu_ids.begin())) )
+				if ((allThreadIDs.size()<rank) || allThreadIDs[0].size()==0 || (!hasExplicitDeviceIDs(gpu_ids)) )
 				{
 					std::cout << "GPU-ids not specified for this rank, threads will automatically be mapped to available devices."<< std::endl;
 				}
@@ -485,7 +485,7 @@ will still yield good performance and possibly a more stable execution. \n" << s
 	{
 		if (node->isLeader())
 		{
-			if (! std::isdigit(*gpu_ids.begin()))
+			if (!hasExplicitDeviceIDs(gpu_ids))
 			{
 				std::cout << std::string(80, '*') << std::endl;
 				std::cout << "GPU-ids not specified and MPI/threads will automatically be mapped to available devices."<< std::endl;
@@ -626,7 +626,7 @@ will still yield good performance and possibly a more stable execution. \n" << s
 
 			bool fullAutomaticMapping;
 			bool semiAutomaticMapping;
-			if (allThreadIDs[node->rank-1].size()==0 || ! std::isdigit(*gpu_ids.begin()) )
+			if (allThreadIDs[node->rank-1].size()==0 || !hasExplicitDeviceIDs(gpu_ids) )
 			{
 				fullAutomaticMapping = true;
 				semiAutomaticMapping = true;

--- a/src/motioncorr_runner.cpp
+++ b/src/motioncorr_runner.cpp
@@ -636,12 +636,10 @@ bool MotioncorrRunner::executeMotioncor2(Micrograph &mic, int rank)
 	}
 	else
 	{
-		if (rank >= allThreadIDs.size())
-			REPORT_ERROR("ERROR: not enough MPI nodes specified for the GPU IDs.");
-
 		command += " -Gpu ";
-		for (int igpu = 0; igpu < allThreadIDs[rank].size(); igpu++)
-			command += allThreadIDs[rank][igpu] + " ";
+		const std::vector<std::string> &rankThreadIDs = getDeviceIDsForRank(allThreadIDs, rank);
+		for (int igpu = 0; igpu < rankThreadIDs.size(); igpu++)
+			command += rankThreadIDs[igpu] + " ";
 	}
 
 	command += " >> " + fn_out + " 2>> " + fn_err;

--- a/src/motioncorr_runner.h
+++ b/src/motioncorr_runner.h
@@ -27,6 +27,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <algorithm>
+#include "src/args.h"
 #include <src/time.h>
 #include "src/metadata_table.h"
 #include "src/image.h"


### PR DESCRIPTION
RELION currently handles explicit GPU-ID mappings inconsistently across MPI programs. Some paths, such as ml_optimiser_mpi.cpp, already support cyclic reuse of shorter GPU-ID lists. For example, --gpu "0:1" can be expanded over more MPI ranks by assigning ranks modulo the number of provided GPU-ID groups. Other paths assume a 1:1 mapping between GPU-ID groups and MPI ranks. In relion_autopick_mpi and relion_find_amyloid_mpi, this can index past the parsed GPU-ID list:
```
  allThreadIDs[node->rank][0]
```
On a single-GPU system, running neural-network/Topaz autopicking with multiple MPI ranks and --gpu "0" can therefore segfault or fail with an uninformative textToInteger error.
```
  [nixos:430042:0:430042] Caught signal 11 (Segmentation fault: address not mapped to object at address (nil))
  [nixos:430046:0:430046] Caught signal 11 (Segmentation fault: address not mapped to object at address 0x21)
  [nixos:430047:0:430047] Caught signal 11 (Segmentation fault: address not mapped to object at address 0x1de088db)
  [nixos:430043:0:430043] Caught signal 11 (Segmentation fault: address not mapped to object at address (nil))
  [nixos:430040:0:430040] Caught signal 11 (Segmentation fault: address not mapped to object at address 0x71)
  [nixos:430050:0:430050] Caught signal 11 (Segmentation fault: address not mapped to object at address (nil))
  [nixos:430052:0:430052] Caught signal 11 (Segmentation fault: address not mapped to object at address 0x61)
  in: /build/source/src/strings.cpp, line 251
  ERROR:
  Error in textToInteger
  [nixos:430054:0:430054] Caught signal 11 (Segmentation fault: address not mapped to object at address (nil))
  [nixos:430045:0:430045] Caught signal 11 (Segmentation fault: address not mapped to object at address (nil))
  --------------------------------------------------------------------------
  MPI_ABORT was invoked on rank 12 in communicator MPI_COMM_WORLD
    Proc: [[10062,1],12]
    Errorcode: 1

  NOTE: invoking MPI_ABORT causes Open MPI to kill all MPI processes.
  You may or may not see output from other processes, depending on
  exactly when Open MPI kills them.
  --------------------------------------------------------------------------
  [nixos:430053:0:430053] Caught signal 11 (Segmentation fault: Sent by the kernel at address (nil))
  [nixos:430049:0:430049] Caught signal 11 (Segmentation fault: address not mapped to object at address (nil))
  [nixos:430044:0:430044] Caught signal 11 (Segmentation fault: address not mapped to object at address (nil))
  [nixos:430048:0:430048] Caught signal 11 (Segmentation fault: address not mapped to object at address (nil))
  --------------------------------------------------------------------------
  prterun has exited due to process rank 12 with PID 0 on node nixos calling
  "abort". This may have caused other processes in the application to be
  terminated by signals sent by prterun (as reported here).
  --------------------------------------------------------------------------
```

This PR centralizes GPU-ID rank mapping in args.{h,cpp}:
```
  getDeviceIDsForRank(allThreadIDs, rank)
```
The helper validates parsed GPU IDs and reuses explicit GPU-ID groups cyclically when there are more MPI ranks than GPU-ID groups. This makes mappings like:

  0
  0:1
  0:1:2:3

work naturally with larger MPI rank counts, while preserving existing fully explicit mappings such as:

  0:1:0:1

It also replaces direct std::isdigit(*gpu_ids.begin()) checks with a helper that safely treats empty GPU-ID strings as automatic mapping. This brings autopicking, amyloid tracing, MotionCor, and AreTomo GPU assignment behavior in line with the existing cyclic behavior in ml_optimiser_mpi.cpp. 

It works for my case ( single GPU ). More test or further modification are welcomed.