### PR TITLE
skip tilt series header read during refinement

### DIFF
--- a/src/exp_model.cpp
+++ b/src/exp_model.cpp
@@ -991,7 +991,7 @@ bool Experiment::read(FileName fn_exp, FileName fn_tomo, FileName fn_motion,
 
                 if (tomo_name != prev_tomo_name)
                 {
-                    tomogram = tomogramSet.loadTomogram(tomo_id, false, false, false, -999, -999, -999, true);  // Ignore tomo size
+                    tomogram = tomogramSet.loadTomogram(tomo_id, false, false, false, -999, -999, -999, true, true);  // Ignore tomo size
                     prev_tomo_name = tomo_name;
 
                     // Tomogram sanity checks

--- a/src/jaz/tomography/tomogram_set.cpp
+++ b/src/jaz/tomography/tomogram_set.cpp
@@ -151,7 +151,7 @@ void TomogramSet::removeTomogram(std::string tomogramName)
 }
 
 Tomogram TomogramSet::loadTomogram(int index, bool loadImageData, bool loadEvenFramesOnly, bool loadOddFramesOnly,
-                                   int _w0, int _h0, int _d0, bool ignore_tomo_size) const //Set loadEven/OddFramesOnly to True to loadImageData from rlnTomoMicrographNameEven/Odd rather than rlnMicrographName
+                                   int _w0, int _h0, int _d0, bool ignore_tomo_size, bool skip_tilt_image_size) const //Set loadEven/OddFramesOnly to True to loadImageData from rlnTomoMicrographNameEven/Odd rather than rlnMicrographName
 {
 	Tomogram out;
 
@@ -208,11 +208,18 @@ Tomogram TomogramSet::loadTomogram(int index, bool loadImageData, bool loadEvenF
         {
             out.hasImage = false;
 
-            t3Vector<long int> isl = ImageFileHelper::getSize(out.tiltSeriesFilename);
+            if (skip_tilt_image_size)
+            {
+                stackSize.z = out.frameCount;
+            }
+            else
+            {
+                t3Vector<long int> isl = ImageFileHelper::getSize(out.tiltSeriesFilename);
 
-            stackSize.x = isl.x;
-            stackSize.y = isl.y;
-            stackSize.z = isl.z;
+                stackSize.x = isl.x;
+                stackSize.y = isl.y;
+                stackSize.z = isl.z;
+            }
 
             // Still set image size in header, as this is used for example in TomoBackprojectProgram::getProjectMatrices
             out.stack.xdim = stackSize.x;
@@ -258,11 +265,15 @@ Tomogram TomogramSet::loadTomogram(int index, bool loadImageData, bool loadEvenF
         	m.getValueSafely(EMDL_MICROGRAPH_NAME, fn_img, 0);
         }
 
-        Image<RFLOAT> I;
-        I.read(fn_img,false); // false means don't read the actual image data, only the header
+        if (!skip_tilt_image_size)
+        {
+            Image<RFLOAT> I;
+            I.read(fn_img,false); // false means don't read the actual image data, only the header
 
-        stackSize.x = XSIZE(I());
-        stackSize.y = YSIZE(I());
+            stackSize.x = XSIZE(I());
+            stackSize.y = YSIZE(I());
+        }
+
         stackSize.z = out.frameCount;
 
         if (loadImageData)

--- a/src/jaz/tomography/tomogram_set.h
+++ b/src/jaz/tomography/tomogram_set.h
@@ -27,7 +27,7 @@ class TomogramSet
         void removeTomogram(std::string tomogramName);
 
         // If max_dose is positive, then only images with cumulativeDose less than or equal to max_dose will be loaded.
-		Tomogram loadTomogram(int index, bool loadImageData, bool loadEvenFrames = false, bool loadOddFrames = false, int w0 = -999, int h0 =-999, int d0 = -999, bool ignore_tomo_size = false) const;
+		Tomogram loadTomogram(int index, bool loadImageData, bool loadEvenFrames = false, bool loadOddFrames = false, int w0 = -999, int h0 =-999, int d0 = -999, bool ignore_tomo_size = false, bool skip_tilt_image_size = false) const;
 
 		int size() const;
         void setProjectionAngles(int tomogramIndex, int frame, RFLOAT xtilt, RFLOAT ytilt, RFLOAT zrot, RFLOAT xshift_angst, RFLOAT yshift_angst);


### PR DESCRIPTION
For STA, 3D refinement cannot be run unless there is a tiltseries.mrcs file present, but 3D refinement does not need to read the tiltseries file (not even for header information; all the alignment / CTF information is already in the tiltseries star file). This can be inconvenient for cases where 3D refinement is run in an environment where the original tiltseries are unavailable (and it fails, even though it shouldn't).