### PR TITLE
use consistent tomogram centre in setProjectionMatrix

### DIFF
--- a/src/jaz/tomography/tomogram.cpp
+++ b/src/jaz/tomography/tomogram.cpp
@@ -41,7 +41,7 @@ void Tomogram::setProjectionMatrix(int f, RFLOAT xtilt, RFLOAT ytilt, RFLOAT zro
     d4Matrix s0, s1, s2, r0, r1, r2;
 
     // Get specimen center
-    t3Vector<double> specimen_center((double)int(w0/2), (double)int(h0/2), (double)int(d0/2) );
+    t3Vector<double> specimen_center(centre.x, centre.y, centre.z);
     s0 = s0.translation(-specimen_center);
 
     // Get specimen shifts (in pixels)


### PR DESCRIPTION
`TomogramSet::loadTomogram` sets `Tomogram::centre` with floating point division (`out.centre = d3Vector(out.w0/2.0, out.h0/2.0, out.d0/2.0)`), which `ParticleSet::getPosition` adds to convert `rlnCenteredCoordinate*Angst` into decentred tomogram pixels. `Tomogram::setProjectionMatrix` recomputes the same quantity with integer division, `specimen_center((double)int(w0/2), ...)`, for the `s0` translation. The two agree for even tomogram dimensions and differ by half a pixel for odd ones, leaving a residual of `centre_float - centre_int` of 0.5 px per odd axis in `projectionMatrices[f] * pos`.

This reaches subtomogram extraction through `TomoExtraction::extractAt2D_Fourier`, which projects the absolute 3D position to locate the crop centre in each tilt image. Odd tomogram dimensions are not prevented and can occur in practice. Supersedes #1286, which proposed the same change framed as a floating point accuracy improvement and was closed on the grounds that integer division is intentional for even-sized boxes. That applies to particle box sizes, which RELION constrains to be even; it does not apply to tomogram dimensions, which are unconstrained. See also #1284.