### PR TITLE
Repair CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,13 +9,13 @@ jobs:
       matrix:
         altcpu: [ON, OFF]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       - name: Install dependencies
         run: |
           sudo apt-get update -q -y && \
-          sudo apt-get install -q -y cmake git build-essential mpi-default-bin mpi-default-dev libfftw3-dev libtiff-dev libfltk1.3-dev
+          sudo apt-get install -q -y cmake git build-essential mpi-default-bin mpi-default-dev libfftw3-dev libtiff-dev libpng-dev libtbb-dev libfltk1.3-dev python3
       - name: Build RELION for Linux x86_64
-        run: mkdir build && cd build && cmake -DALTCPU=${{ matrix.altcpu }} .. && make
+        run: mkdir build && cd build && cmake -DALTCPU=${{ matrix.altcpu }} -DCUDA=OFF -DFETCH_WEIGHTS=OFF -DPYTHON_EXE_PATH=/usr/bin/python3 -DTORCH_HOME_PATH=/tmp .. && make
 
   build_on_aarch64:
     runs-on: ubuntu-latest
@@ -23,9 +23,9 @@ jobs:
       matrix:
         altcpu: [ON, OFF]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       - name: Build RELION for Linux aarch64
-        uses: uraimo/run-on-arch-action@v2
+        uses: uraimo/run-on-arch-action@v3.1.0
         with:
           arch: aarch64
           distro: ubuntu20.04
@@ -34,10 +34,10 @@ jobs:
             --volume "${PWD}:/relion" 
           install: |
             apt-get update -q -y
-            apt-get install -q -y cmake git build-essential mpi-default-bin mpi-default-dev libfftw3-dev libtiff-dev libfltk1.3-dev
+            apt-get install -q -y cmake git build-essential mpi-default-bin mpi-default-dev libfftw3-dev libtiff-dev libpng-dev libtbb-dev libfltk1.3-dev python3
           run: |
             cd /relion
             mkdir build
             cd build
-            cmake -DALTCPU=${{ matrix.altcpu }} ..
+            cmake -DALTCPU=${{ matrix.altcpu }} -DCUDA=OFF -DFETCH_WEIGHTS=OFF -DPYTHON_EXE_PATH=/usr/bin/python3 -DTORCH_HOME_PATH=/tmp ..
             make


### PR DESCRIPTION
Restore the repository's supported CI build configurations.

- CI jobs selected earlier action and runtime releases. Update workflow actions and runtime images to supported releases. [`.github/workflows/build.yml`](https://github.com/3dem/relion/pull/1355/changes#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721): [`12`](https://github.com/3dem/relion/pull/1355/changes#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L12), [`26-28`](https://github.com/3dem/relion/pull/1355/changes#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L26-L28)
- CI configured build variants without their required native dependencies. Install only the dependencies required by each build variant. [`.github/workflows/build.yml`](https://github.com/3dem/relion/pull/1355/changes#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721): [`16`](https://github.com/3dem/relion/pull/1355/changes#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L16), [`37`](https://github.com/3dem/relion/pull/1355/changes#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L37)
- CPU-only jobs left optional setup enabled and did not select their Python interpreter. Disable unused setup and provide the system Python paths. [`.github/workflows/build.yml`](https://github.com/3dem/relion/pull/1355/changes#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721): [`18`](https://github.com/3dem/relion/pull/1355/changes#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L18), [`42`](https://github.com/3dem/relion/pull/1355/changes#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L42)
