### PR TITLE
pyproject.toml: add scipy and dill, used directly but never declared

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,8 @@ dependencies = [
     "lru-dict",
     "superqt",
     "morphosamplers",
+    "scipy",
+    "dill",
 ]
 
 # extras


### PR DESCRIPTION
get_particle_poses/{spheres,filaments}.py import scipy directly, and scripts/filament_selection.in does `import dill as pickle` - both only ever installed by accident, transitively, via other packages that happen to depend on them.