### PR TITLE
align_tilt_series: make the AreTomo backend import optional

### DIFF
--- a/src/tomography_python_programs/align_tilt_series/__init__.py
+++ b/src/tomography_python_programs/align_tilt_series/__init__.py
@@ -1,7 +1,13 @@
 # Import decorated command line interface functions first
 from .imod import fiducials_cli
 from .imod import patch_tracking_cli
-from .aretomo import aretomo_cli
+try:
+    from .aretomo import aretomo_cli
+except ImportError:
+    # AreTomo support is optional (it's a closed-source binary tied to old
+    # CUDA versions) - fall back gracefully so the IMOD-based backends
+    # (fiducials/patch tracking) still work without it.
+    aretomo_cli = None
 from ._job_utils import write_global_output
 
 # Then import the cli, it will be decorated with all programs (subcommands)


### PR DESCRIPTION
It's eagerly imported at module load, so the whole command fails to start without AreTomo installed - even for IMOD-only use (fiducials/patch tracking, unaffected by AreTomo's availability). AreTomo itself is a closed-source binary tied to old CUDA versions, so it's reasonable for it to be genuinely optional.