### PR TITLE
Address threaded zernike cache and groupUsed race conditions

### DIFF
--- a/src/jaz/math/Zernike.cpp
+++ b/src/jaz/math/Zernike.cpp
@@ -39,16 +39,21 @@ double Zernike::R(int m, int n, double rho)
 	
 	if ((n - m) % 2 == 1) return 0.0;
 	
-	if (R_coeffs.size() <= n)
+	std::vector<double> coeffs_row;
+	#pragma omp critical(Zernike_R_coeffs)
 	{
-		prepCoeffs(n);
+		if (R_coeffs.size() <= n)
+		{
+			prepCoeffs(n);
+		}
+		coeffs_row = R_coeffs[n][m];
 	}
 	
 	double out = 0.0;
 	
 	for (int k = 0; k <= (n-m)/2; k++)
 	{
-		out += R_coeffs[n][m][k] * pow(rho, n - 2*k);
+		out += coeffs_row[k] * pow(rho, n - 2*k);
 	}
 	
 	return out;

--- a/src/jaz/single_particle/ctf/aberration_estimator.cpp
+++ b/src/jaz/single_particle/ctf/aberration_estimator.cpp
@@ -179,7 +179,7 @@ void AberrationEstimator::parametricFit(
 	const int gc = mdts.size();
 	const int ogc = obsModel->numberOfOpticsGroups();
 
-	std::vector<bool> groupUsed(ogc,false);
+	std::vector<char> groupUsed(ogc,false);
 
 	#pragma omp parallel for num_threads(nr_omp_threads)
 	for (int og = 0; og < ogc; og++)

--- a/src/jaz/single_particle/ctf/tilt_estimator.cpp
+++ b/src/jaz/single_particle/ctf/tilt_estimator.cpp
@@ -179,7 +179,7 @@ void TiltEstimator::parametricFit(
 	const int gc = mdts.size();
 	const int ogc = obsModel->numberOfOpticsGroups();
 
-	std::vector<bool> groupUsed(ogc, false);
+	std::vector<char> groupUsed(ogc, false);
 
 	#pragma omp parallel for num_threads(nr_omp_threads)
 	for (int og = 0; og < ogc; og++)


### PR DESCRIPTION
Tracking down sporadic crashes when running CTF refinement, I think I located a 2 thread-safety/race conditions. These crashes are quite rare, but occur often enough to motivate me to look into it.

I think the most common cause of what I was seeing is the R_coeffs cache vector in Zernike.cpp . If multiple threads try to populate or grow it at once (like when the cache is totally cold), I think the subsequent assignment back to R_coeffs is not thread safe and bad things can ensue. Possibly also one thread could be reading while another is still assigning back. CTF refinement indeed calls this in multithreaded sections via (for example) AberrationEstimator::parametricFit -> TiltHelper::fitEvenZernike -> computeEvenZernike -> Zernike::Z -> Zernike::R

You could avoid a lock like what I've implemented here by instead making every application precompute the R_coeffs table upfront (it would have to know its maximum `n`) before any multithreaded work, but the code in Zernike.cpp is used in several places and I was nervous to make that change. I didn't find that this change affected performance noticeably, but all I've tested is single particle CTF refinement because that's where I could reproduce crashes, as well as a handful of single particle Refine3D jobs as a quick check.

---

even more rare, I think, was an issue where modifications to a `std::vector<bool>` specifically are not guaranteed thread safe (I'm pretty sure?), so it's more robust as char and doesn't risk corrupting the assignment of whether optics group are occupied/used. 