### PR TITLE
Fix MPI buffer-size mismatch in multibody combineAllWeightedSums (MPI_ERR_TRUNCATE)

### DIFF
--- a/src/ml_optimiser_mpi.cpp
+++ b/src/ml_optimiser_mpi.cpp
@@ -3661,6 +3661,9 @@ void MlOptimiserMpi::calculateExpectedAngularErrors(long int my_first_part_id, l
 	// The reconstructing follower Bcast acc_rottilt, acc_psi, acc_trans to all other nodes!
 	node->relion_MPI_Bcast(&acc_rot, 1, MY_MPI_DOUBLE, first_follower, MPI_COMM_WORLD);
 	node->relion_MPI_Bcast(&acc_trans, 1, MY_MPI_DOUBLE, first_follower, MPI_COMM_WORLD);
+	// Also Bcast full per-body/class vectors, e.g. for synching body fixing logic during multibody refinement
+	node->relion_MPI_Bcast(&mymodel.acc_rot[0], mymodel.acc_rot.size(), MY_MPI_DOUBLE, first_follower, MPI_COMM_WORLD);
+	node->relion_MPI_Bcast(&mymodel.acc_trans[0], mymodel.acc_trans.size(), MY_MPI_DOUBLE, first_follower, MPI_COMM_WORLD);
 }
 
 void MlOptimiserMpi::updateAngularSamplingGrad(long int my_first_part_id, long int my_last_part_id, bool myverb)


### PR DESCRIPTION
Found the fix for my issue #1319  

In `MlOptimiserMpi::calculateExpectedAngularErrors()`, MPI rank 1 ("first_follower") calculates the per class/body rotation and translation accuracies. It syncs the best (minimum numerical value) of both vectors (stored in the scalar `acc_trans` and `acc_rot`) to the other MPI processes, who then each run the logic in `updateAngularSampling()` themselves. But as they're all operating from synced data they should reach the same conclusions, and most decisions are done based on these single "best" values so everything is fine.

Except that the decision in `updateAngularSampling()` whether or not to hold a particular body fixed needs the individual per-body values, thus the full vector. As it stands, this is not broadcast/synced and so the fixed-ness of bodies can diverge on other ranks because they never change their copy of this vector from the default initialization of all zeros. When bodies are being fixed on rank 1, this can lead to different `wsum_model.pdf_direction[]` sizes versus the other ranks and the `MPI_ERR_TRUNCATE` crash I describe in that issue.

This adds Bcast of the full per-body/class accuracies alongside the existing best/minimum value Bcast.

(A almost-entirely-pointless side effect of this is that, even for normal Refine3D runs, `run_it*_half2_model.star` files will now have real values instead of zeros in the printed `data_model_classes->rlnAccuracyRotations` & `rlnAccuracyTranslationsAngst` fields, whereas currently those are all zeros)