### PR TITLE
Polish: reduce motion-refinement memory usage

### DIFF
--- a/src/jaz/image/buffered_image.h
+++ b/src/jaz/image/buffered_image.h
@@ -1,6 +1,8 @@
 #ifndef JAZ_VECTOR_IMAGE_H
 #define JAZ_VECTOR_IMAGE_H
 
+#include <utility>
+
 #include "raw_image.h"
 
 
@@ -15,6 +17,7 @@ class BufferedImage : public RawImage<T>
 		BufferedImage();
 		BufferedImage(size_t xdim, size_t ydim = 1, size_t zdim = 1);
 		BufferedImage(const BufferedImage& vi);
+		BufferedImage(BufferedImage&& vi) noexcept;
 		BufferedImage(const RawImage<T>& vi);
 		BufferedImage(const Image<T>& vi);
 		BufferedImage(std::string filename);
@@ -37,6 +40,7 @@ class BufferedImage : public RawImage<T>
 		RawImage<T> getRef();
 		
 		BufferedImage& operator = (const BufferedImage& other);
+		BufferedImage& operator = (BufferedImage&& other) noexcept;
 };
 
 
@@ -72,6 +76,27 @@ BufferedImage<T>& BufferedImage<T>::operator = (const BufferedImage<T>& other)
 }
 
 template <class T>
+BufferedImage<T>& BufferedImage<T>::operator = (BufferedImage<T>&& other) noexcept
+{
+	if (this != &other)
+	{
+		this->xdim = other.xdim;
+		this->ydim = other.ydim;
+		this->zdim = other.zdim;
+		dataVec = std::move(other.dataVec);
+		this->data = dataVec.data();
+
+		other.xdim = 0;
+		other.ydim = 0;
+		other.zdim = 0;
+		other.dataVec.clear();
+		other.data = 0;
+	}
+
+	return *this;
+}
+
+template <class T>
 BufferedImage<T>::BufferedImage()
 	: RawImage<T>()
 {}
@@ -90,6 +115,20 @@ BufferedImage<T>::BufferedImage(const BufferedImage<T>& vi)
 	  dataVec(vi.dataVec)
 {
 	RawImage<T>::data = &(dataVec[0]);
+}
+
+template <class T>
+BufferedImage<T>::BufferedImage(BufferedImage<T>&& vi) noexcept
+	:   RawImage<T>(vi.xdim, vi.ydim, vi.zdim, 0),
+	  dataVec(std::move(vi.dataVec))
+{
+	RawImage<T>::data = dataVec.data();
+
+	vi.xdim = 0;
+	vi.ydim = 0;
+	vi.zdim = 0;
+	vi.dataVec.clear();
+	vi.data = 0;
 }
 
 template <class T>

--- a/src/jaz/image/contiguous_image_stack.h
+++ b/src/jaz/image/contiguous_image_stack.h
@@ -1,0 +1,93 @@
+#ifndef JAZ_CONTIGUOUS_IMAGE_STACK_H
+#define JAZ_CONTIGUOUS_IMAGE_STACK_H
+
+#include <src/image.h>
+#include <src/jaz/image/raw_image.h>
+
+#include <vector>
+
+
+template <typename T>
+class ContiguousImageStack
+{
+	public:
+
+		ContiguousImageStack()
+			: particle_count(0), frame_count(0), width(0), height(0)
+		{}
+
+		ContiguousImageStack(const ContiguousImageStack&) = delete;
+		ContiguousImageStack& operator = (const ContiguousImageStack&) = delete;
+
+		void resize(long int particleCount, long int frameCount,
+				long int width, long int height)
+		{
+			images.clear();
+
+			particle_count = particleCount;
+			frame_count = frameCount;
+			this->width = width;
+			this->height = height;
+
+			if (particleCount <= 0 || frameCount <= 0 || width <= 0 || height <= 0)
+			{
+				storage.clear();
+				particle_count = frame_count = this->width = this->height = 0;
+				return;
+			}
+
+			const long int imageCount = particleCount * frameCount;
+			storage.data.setDimensions(width, height, 1, imageCount);
+			storage.data.coreAllocateReuse();
+
+			images.resize(imageCount);
+
+			const long int imageSize = width * height;
+			for (long int i = 0; i < imageCount; i++)
+			{
+				images[i].data.setDimensions(width, height, 1, 1);
+				images[i].data.data = storage.data.data + i * imageSize;
+				images[i].data.destroyData = false;
+			}
+		}
+
+		long int particleCount() const { return particle_count; }
+		long int frameCount() const { return frame_count; }
+		long int xdim() const { return width; }
+		long int ydim() const { return height; }
+
+		Image<T>& operator () (long int particle, long int frame)
+		{
+			return images[particle * frame_count + frame];
+		}
+
+		const Image<T>& operator () (long int particle, long int frame) const
+		{
+			return images[particle * frame_count + frame];
+		}
+
+		RawImage<T> getParticleRef(long int particle)
+		{
+			return RawImage<T>(
+				width, height, frame_count,
+				storage.data.data + particle * frame_count * width * height);
+		}
+
+		const RawImage<T> getParticleRef(long int particle) const
+		{
+			return RawImage<T>(
+				width, height, frame_count,
+				storage.data.data + particle * frame_count * width * height);
+		}
+
+		const T* data() const { return storage.data.data; }
+		T* data() { return storage.data.data; }
+
+	private:
+
+		long int particle_count, frame_count, width, height;
+		Image<T> storage;
+		std::vector<Image<T>> images;
+};
+
+#endif

--- a/src/jaz/single_particle/img_proc/filter_helper.cpp
+++ b/src/jaz/single_particle/img_proc/filter_helper.cpp
@@ -407,6 +407,27 @@ Image<Complex> FilterHelper::cropCorner2D(const Image<Complex>& img, int w, int 
     return out;
 }
 
+void FilterHelper::cropCorner2D(const Image<Complex>& img, Image<Complex>& out)
+{
+	const int w = out.data.xdim;
+	const int h = out.data.ydim;
+	const int w1 = img.data.xdim;
+	const int h1 = img.data.ydim;
+
+	for (int y = 0; y < h1; y++)
+	for (int x = 0; x < w1; x++)
+	{
+		const int x1 = x;
+		const int y1 = y < h1 / 2? y : y - h1;
+
+		if (x1 < w && y1 < h / 2 && y1 >= -h / 2)
+		{
+			const int y0 = y1 < 0? y1 + h : y1;
+			DIRECT_A2D_ELEM(out.data, y0, x1) = DIRECT_A2D_ELEM(img.data, y, x);
+		}
+	}
+}
+
 Image<RFLOAT> FilterHelper::zeroOutsideCorner2D(Image<RFLOAT> &img, double radius)
 {
     const int w = img.data.xdim;

--- a/src/jaz/single_particle/img_proc/filter_helper.h
+++ b/src/jaz/single_particle/img_proc/filter_helper.h
@@ -65,6 +65,7 @@ class FilterHelper
         static Image<RFLOAT> padCorner2D(const Image<RFLOAT> &img, int w, int h);
         static Image<RFLOAT> cropCorner2D(const Image<RFLOAT> &img, int w, int h);
         static Image<Complex> cropCorner2D(const Image<Complex> &img, int w, int h);
+        static void cropCorner2D(const Image<Complex>& img, Image<Complex>& out);
         static Image<RFLOAT> zeroOutsideCorner2D(Image<RFLOAT>& img, double radius);
         static void GaussianEnvelopeCorner2D(Image<RFLOAT>& img, double sigma);
 		static Image<RFLOAT> raisedCosEnvCorner2D(Image<RFLOAT>& img, double radIn, double radOut);

--- a/src/jaz/single_particle/micrograph_handler.cpp
+++ b/src/jaz/single_particle/micrograph_handler.cpp
@@ -351,9 +351,10 @@ void MicrographHandler::validatePixelSize(RFLOAT angpix) const
 	}
 }
 
-std::vector<std::vector<Image<Complex>>> MicrographHandler::loadMovie(
+void MicrographHandler::loadMovie(
 		const MetaDataTable &mdt, int s,
 		double angpix, std::vector<ParFourierTransformer>& fts,
+		ContiguousImageStack<Complex>& movie,
 		const std::vector<std::vector<gravis::d2Vector>>* offsets_in,
 		std::vector<std::vector<gravis::d2Vector>>* offsets_out,
 		double data_angpix,
@@ -430,8 +431,6 @@ std::vector<std::vector<Image<Complex>>> MicrographHandler::loadMovie(
 				DIRECT_MULTIDIM_ELEM(defectMask, n) = true;
 	}
 	
-	BufferedImage<float> muGraph;
-	
 	RawImage<RFLOAT> gainRef_new(lastGainRef);
 	RawImage<bool> defectMask_new(defectMask);
 	
@@ -448,7 +447,19 @@ std::vector<std::vector<Image<Complex>>> MicrographHandler::loadMovie(
 
 	const int frame0 = returnSingleFrame? single_frame_relative_index : firstFrame;
 	const int fc = returnSingleFrame? 1 : lastFrame - firstFrame + 1;
-				
+
+	std::vector<Image<RFLOAT>> extractionAuxReal;
+	std::vector<Image<Complex>> extractionAuxFourier;
+
+	auto extractFrame = [&](const RawImage<float>& frame, long int f)
+	{
+		SpaExtraction::extractMovieFrameFS(
+			mdt, frame, f, fc, s,
+			angpix, coords_angpix, movie_angpix, data_angpix,
+			offsets_in, offsets_out, movie, fts,
+			extractionAuxReal, extractionAuxFourier);
+	};
+
 	if (isEER)			
 	{
 		if (eer_upsampling < 0)
@@ -461,47 +472,39 @@ std::vector<std::vector<Image<Complex>>> MicrographHandler::loadMovie(
 			eer_grouping = micrograph.getEERGrouping();
 		}
 
-		muGraph = MovieLoader::readEER<float>(
+		MovieLoader::readEERFrames<float>(
 			movieFn, gainRefToUse, defectMaskToUse,
 			frame0, fc,
 			eer_upsampling, eer_grouping,
-			nr_omp_threads);
+			nr_omp_threads, extractFrame);
 	}
 	else
 	{
-		muGraph = MovieLoader::readDense<float>(
+		MovieLoader::readDenseFrames<float>(
 			movieFn, gainRefToUse, defectMaskToUse,
 			frame0, fc,
 			hotCutoff,
-			nr_omp_threads);
+			nr_omp_threads, extractFrame);
 	}
 	
-	std::vector<std::vector<Image<Complex>>> movie = SpaExtraction::extractMovieStackFS(
-			mdt, muGraph, s,
-			angpix, coords_angpix, movie_angpix, data_angpix,
-			offsets_in, offsets_out, 
-			nr_omp_threads);
-	
-	const int pc = movie.size();
+	const int pc = movie.particleCount();
 
 	if (!returnSingleFrame)
 	{
 		#pragma omp parallel for num_threads(nr_omp_threads)
 		for (int p = 0; p < pc; p++)
 		{
-			RFLOAT scale2 = StackHelper::computePower(movie[p], false);
+			RFLOAT scale2 = StackHelper::computePower(movie.getParticleRef(p), false);
 			
 			for (int f = 0; f < fc; f++)
 			{
 				// NOTE: sqrt(fc) is a legacy scaling factor.
 				// It probably shouldn't be there.
 				//                   --JZ
-				RawImage<Complex>(movie[p][f]) /= s * sqrt(scale2 / fc); 
+				RawImage<Complex>(movie(p, f)) /= s * sqrt(scale2 / fc);
 			}
 		}
 	}
-
-	return movie;
 }
 
 void MicrographHandler::loadInitialTracks(

--- a/src/jaz/single_particle/micrograph_handler.h
+++ b/src/jaz/single_particle/micrograph_handler.h
@@ -26,6 +26,7 @@
 
 #include <src/jaz/gravis/t2Vector.h>
 #include <src/jaz/single_particle/parallel_ft.h>
+#include <src/jaz/image/contiguous_image_stack.h>
 
 #include <src/micrograph_model.h>
 #include <src/image.h>
@@ -76,11 +77,11 @@ class MicrographHandler
 		const std::vector<MetaDataTable>& mdts,
 		int fc, int verb);
 
-	// load a movie and extract all particles
-	// returns a per-particle vector of per-frame images of size (s/2+1) x s
-	std::vector<std::vector<Image<Complex>>> loadMovie(
+	// load a movie and extract all particles into contiguous per-frame storage
+	void loadMovie(
 		const MetaDataTable& mdt, int s, double angpix, 
 		std::vector<ParFourierTransformer>& fts,
+		ContiguousImageStack<Complex>& movie,
 		const std::vector<std::vector<gravis::d2Vector>>* offsets_in = 0,
 		std::vector<std::vector<gravis::d2Vector>>* offsets_out = 0,
 		double data_angpix = -1,

--- a/src/jaz/single_particle/motion/frame_recombiner.cpp
+++ b/src/jaz/single_particle/motion/frame_recombiner.cpp
@@ -317,6 +317,7 @@ void FrameRecombiner::process(const std::vector<MetaDataTable>& mdts, long g_sta
 		
 		BufferedImage<Complex> sumStack(sh_out[ogmg], s_out[ogmg], pc);
 		sumStack.fill(Complex(0,0));
+		ContiguousImageStack<Complex> fullFrame;
 
 		// This is an ugly code duplication.
 		// Frame-by-frame reading (the normal route) is more memory efficient but
@@ -325,8 +326,8 @@ void FrameRecombiner::process(const std::vector<MetaDataTable>& mdts, long g_sta
 		// CompressedMRCReader (and probably EERRenderer).
 		if (readAtOnce)
 		{
-			std::vector<std::vector<Image<Complex>>> fullFrame = micrographHandler->loadMovie(
-						mdtOut, s_out[ogmg], angpix_out[ogmg], fts,
+			micrographHandler->loadMovie(
+						mdtOut, s_out[ogmg], angpix_out[ogmg], fts, fullFrame,
 						&priorShift, &shift, data_angpix[ogmg]);
 
 			for (int f = 0; f < fc; f++)
@@ -334,7 +335,7 @@ void FrameRecombiner::process(const std::vector<MetaDataTable>& mdts, long g_sta
 				#pragma omp parallel for num_threads(nr_omp_threads)
 				for (int p = 0; p < pc; p++)
 				{
-					RawImage<Complex> obs(fullFrame[p][f]);
+					RawImage<Complex> obs(fullFrame(p, f));
 
 					Translation::shiftInFourierSpace2D(obs, -shift[p][f].x, -shift[p][f].y);
 
@@ -357,14 +358,14 @@ void FrameRecombiner::process(const std::vector<MetaDataTable>& mdts, long g_sta
 					priorShift_f[p] = {priorShift[p][f]};
 				}
 
-				std::vector<std::vector<Image<Complex>>> fullFrame = micrographHandler->loadMovie(
-							mdtOut, s_out[ogmg], angpix_out[ogmg], fts,
+				micrographHandler->loadMovie(
+							mdtOut, s_out[ogmg], angpix_out[ogmg], fts, fullFrame,
 							&priorShift_f, &shift, data_angpix[ogmg], f);
 
 				#pragma omp parallel for num_threads(nr_omp_threads)
 				for (int p = 0; p < pc; p++)
 				{
-					RawImage<Complex> obs(fullFrame[p][0]);
+					RawImage<Complex> obs(fullFrame(p, 0));
 
 					Translation::shiftInFourierSpace2D(obs, -shift[p][0].x, -shift[p][0].y);
 

--- a/src/jaz/single_particle/motion/gp_motion_fit.cpp
+++ b/src/jaz/single_particle/motion/gp_motion_fit.cpp
@@ -28,7 +28,7 @@
 using namespace gravis;
 
 GpMotionFit::GpMotionFit(
-		const std::vector<std::vector<Image<double>>>& correlation,
+		const ContiguousImageStack<double>& correlation,
 		double cc_pad,
 		double sig_vel_px, double sig_div_px, double sig_acc_px,
 		int maxDims,
@@ -37,8 +37,8 @@ GpMotionFit::GpMotionFit(
 		int threads, bool expKer)
 	:
 	  expKer(expKer),
-	  pc(correlation.size()),
-	  fc(correlation[0].size()),
+	  pc(correlation.particleCount()),
+	  fc(correlation.frameCount()),
 	  threads(threads),
 	  cc_pad(cc_pad),
 	  sig_vel_px(sig_vel_px),
@@ -103,7 +103,7 @@ double GpMotionFit::f(const std::vector<double> &x) const
 		for (int f = 0; f < fc; f++)
 		{
 			e_t[pad*t] -= Interpolation::cubicXY(
-						correlation[p][f],
+						correlation(p, f),
 						cc_pad * (pos[p][f].x + perFrameOffsets[f].x),
 						cc_pad * (pos[p][f].y + perFrameOffsets[f].y),
 						0, 0, true);
@@ -176,7 +176,7 @@ double GpMotionFit::f(const std::vector<double> &x, void* tempStorage) const
 
 		for (int f = 0; f < fc; f++)
 		{
-			const double epf = Interpolation::cubicXY(correlation[p][f],
+			const double epf = Interpolation::cubicXY(correlation(p, f),
 													  cc_pad * (ts->pos[p][f].x + perFrameOffsets[f].x),
 													  cc_pad * (ts->pos[p][f].y + perFrameOffsets[f].y),
 													  0, 0, true);
@@ -246,7 +246,7 @@ void GpMotionFit::grad(const std::vector<double> &x,
 		for (int f = 0; f < fc; f++)
 		{
 			d2Vector vr = Interpolation::cubicXYgrad(
-						correlation[p][f],
+						correlation(p, f),
 						cc_pad * (pos[p][f].x + perFrameOffsets[f].x),
 						cc_pad * (pos[p][f].y + perFrameOffsets[f].y),
 						0, 0, true);
@@ -352,7 +352,7 @@ void GpMotionFit::grad(const std::vector<double> &x,
 		for (int f = 0; f < fc; f++)
 		{
 			d2Vector vr = Interpolation::cubicXYgrad(
-						correlation[p][f],
+						correlation(p, f),
 						cc_pad * (ts->pos[p][f].x + perFrameOffsets[f].x),
 						cc_pad * (ts->pos[p][f].y + perFrameOffsets[f].y),
 						0, 0, true);

--- a/src/jaz/single_particle/motion/gp_motion_fit.h
+++ b/src/jaz/single_particle/motion/gp_motion_fit.h
@@ -24,6 +24,7 @@
 #include <src/image.h>
 #include <src/jaz/optimization/optimization.h>
 #include <src/jaz/gravis/t2Vector.h>
+#include <src/jaz/image/contiguous_image_stack.h>
 #include <vector>
 
 class GpMotionFit : public DifferentiableOptimization
@@ -31,7 +32,7 @@ class GpMotionFit : public DifferentiableOptimization
     public:
 
         GpMotionFit(
-                const std::vector<std::vector<Image<double>>>& correlation,
+                const ContiguousImageStack<double>& correlation,
                 double cc_pad,
 				double sig_vel_px, double sig_div_px, double sig_acc_px,
                 int maxDims,
@@ -74,7 +75,7 @@ class GpMotionFit : public DifferentiableOptimization
         Matrix2D<RFLOAT> basis;
         std::vector<double> eigenVals;
 
-        const std::vector<std::vector<Image<double>>>& correlation;
+        const ContiguousImageStack<double>& correlation;
         const std::vector<gravis::d2Vector>& positions;
         const std::vector<gravis::d2Vector>& perFrameOffsets;
 };

--- a/src/jaz/single_particle/motion/motion_estimator.cpp
+++ b/src/jaz/single_particle/motion/motion_estimator.cpp
@@ -271,8 +271,8 @@ void MotionEstimator::process(
 			ZIO::makeDir(newdir);
 		}
 
-		std::vector<std::vector<Image<Complex>>> movie;
-		std::vector<std::vector<Image<RFLOAT>>> movieCC;
+		ContiguousImageStack<Complex> movie;
+		ContiguousImageStack<RFLOAT> movieCC;
 		std::vector<d2Vector> positions(pc);
 		std::vector<std::vector<d2Vector>> initialTracks(pc, std::vector<d2Vector>(fc));
 		std::vector<d2Vector> globComp(fc);
@@ -386,8 +386,8 @@ void MotionEstimator::prepMicrograph(
 		const MetaDataTable &mdt, std::vector<ParFourierTransformer>& fts,
 		const std::vector<Image<RFLOAT>>& dmgWeight,
 		int ogmg,
-		std::vector<std::vector<Image<Complex>>>& movie,
-		std::vector<std::vector<Image<RFLOAT>>>& movieCC,
+		ContiguousImageStack<Complex>& movie,
+		ContiguousImageStack<RFLOAT>& movieCC,
 		std::vector<d2Vector>& positions,
 		std::vector<std::vector<d2Vector>>& initialTracks,
 		std::vector<d2Vector>& globComp)
@@ -413,7 +413,7 @@ void MotionEstimator::prepMicrograph(
 				mdt, s[ogmg], angpix[ogmg], fts,
 				positions, myInitialTracks, unregGlob, myGlobComp, 0, 0, -1); // throws exceptions*/
 	
-	movie = micrographHandler->loadMovie(mdt, s[ogmg], angpix[ogmg], fts);
+	micrographHandler->loadMovie(mdt, s[ogmg], angpix[ogmg], fts, movie);
 	micrographHandler->loadInitialTracks(mdt, angpix[ogmg], positions, myInitialTracks, unregGlob, myGlobComp);
 
 	/*const MetaDataTable &mdt, double angpix,
@@ -437,12 +437,12 @@ void MotionEstimator::prepMicrograph(
 			for (int f = 0; f < fc; f++)
 			{
 
-				MotionHelper::noiseNormalize(movie[p][f], sigma2, movie[p][f]);
+				MotionHelper::noiseNormalize(movie(p, f), sigma2, movie(p, f));
 			}
 		}
 	}
 
-	movieCC = MotionHelper::movieCC(movie, preds, dmgWeight, cc_pad, nr_omp_threads);
+	MotionHelper::movieCC(movie, preds, dmgWeight, cc_pad, nr_omp_threads, movieCC);
 
 	if (global_init || myInitialTracks.size() == 0)
 	{
@@ -523,7 +523,7 @@ void MotionEstimator::prepMicrograph(
 }
 
 std::vector<std::vector<d2Vector>> MotionEstimator::optimize(
-		const std::vector<std::vector<Image<double>>>& movieCC,
+		const ContiguousImageStack<double>& movieCC,
 		const std::vector<std::vector<gravis::d2Vector>>& inTracks,
 		double sig_vel_px, double sig_acc_px, double sig_div_px,
 		const std::vector<gravis::d2Vector>& positions,
@@ -572,6 +572,37 @@ std::vector<std::vector<d2Vector>> MotionEstimator::optimize(
 }
 
 std::vector<std::vector<d2Vector>> MotionEstimator::optimize(
+		const ContiguousImageStack<float>& movieCC,
+		const std::vector<std::vector<gravis::d2Vector>>& inTracks,
+		double sig_vel_px, double sig_acc_px, double sig_div_px,
+		const std::vector<gravis::d2Vector>& positions,
+		const std::vector<gravis::d2Vector>& globComp) const
+{
+	const int pc = movieCC.particleCount();
+	const int fc = movieCC.frameCount();
+	const int w = movieCC.xdim();
+	const int h = movieCC.ydim();
+
+	ContiguousImageStack<double> CCd;
+	CCd.resize(pc, fc, w, h);
+
+	#pragma omp parallel for num_threads(nr_omp_threads)
+	for (int p = 0; p < pc; p++)
+	{
+		for (int f = 0; f < fc; f++)
+		{
+			for (int y = 0; y < h; y++)
+			for (int x = 0; x < w; x++)
+			{
+				CCd(p, f)(y,x) = movieCC(p, f)(y,x);
+			}
+		}
+	}
+
+	return optimize(CCd, inTracks, sig_vel_px, sig_acc_px, sig_div_px, positions, globComp);
+}
+
+std::vector<std::vector<d2Vector>> MotionEstimator::optimize(
 		const std::vector<std::vector<Image<float>>>& movieCC,
 		const std::vector<std::vector<gravis::d2Vector>>& inTracks,
 		double sig_vel_px, double sig_acc_px, double sig_div_px,
@@ -583,26 +614,21 @@ std::vector<std::vector<d2Vector>> MotionEstimator::optimize(
 	const int w = movieCC[0][0].data.xdim;
 	const int h = movieCC[0][0].data.ydim;
 
-	std::vector<std::vector<Image<double>>> CCd(pc);
+	ContiguousImageStack<float> contiguous;
+	contiguous.resize(pc, fc, w, h);
 
 	#pragma omp parallel for num_threads(nr_omp_threads)
 	for (int p = 0; p < pc; p++)
+	for (int f = 0; f < fc; f++)
+	for (int y = 0; y < h; y++)
+	for (int x = 0; x < w; x++)
 	{
-		CCd[p].resize(fc);
-
-		for (int f = 0; f < fc; f++)
-		{
-			CCd[p][f] = Image<double>(w,h);
-
-			for (int y = 0; y < h; y++)
-			for (int x = 0; x < w; x++)
-			{
-				CCd[p][f](y,x) = movieCC[p][f](y,x);
-			}
-		}
+		contiguous(p, f)(y, x) = movieCC[p][f](y, x);
 	}
 
-	return optimize(CCd, inTracks, sig_vel_px, sig_acc_px, sig_div_px, positions, globComp);
+	return optimize(
+		contiguous, inTracks, sig_vel_px, sig_acc_px, sig_div_px,
+		positions, globComp);
 }
 
 std::vector<Image<RFLOAT>> MotionEstimator::computeDamageWeights(int opticsGroup)
@@ -613,7 +639,7 @@ std::vector<Image<RFLOAT>> MotionEstimator::computeDamageWeights(int opticsGroup
 }
 
 void MotionEstimator::updateFCC(
-		const std::vector<std::vector<Image<Complex>>>& movie,
+		ContiguousImageStack<Complex>& movie,
 		const std::vector<std::vector<d2Vector>>& tracks,
 		const MetaDataTable& mdt,
 		std::vector<Image<RFLOAT>>& tables,
@@ -628,11 +654,10 @@ void MotionEstimator::updateFCC(
 		int threadnum = omp_get_thread_num();
 		const int og = obsModel->getOpticsGroup(mdt, p);
 
-		std::vector<Image<Complex>> obs = movie[p];
-
 		for (int f = 0; f < fc; f++)
 		{
-			shiftImageInFourierTransform(obs[f](), obs[f](), s[og], -tracks[p][f].x, -tracks[p][f].y);
+			Image<Complex>& obs = movie(p, f);
+			shiftImageInFourierTransform(obs(), obs(), s[og], -tracks[p][f].x, -tracks[p][f].y);
 		}
 
 		Image<Complex> pred = reference->predict(
@@ -640,10 +665,13 @@ void MotionEstimator::updateFCC(
 
 		const double scale = (s_ref * angpix_ref)/(s[og] * angpix[og]);
 
-		FscHelper::updateFscTable(
-			obs, pred, scale,
-			tables[threadnum],
-			weights0[threadnum], weights1[threadnum]);
+		for (int f = 0; f < fc; f++)
+		{
+			FscHelper::updateFscTable(
+				movie(p, f), f, pred, scale,
+				tables[threadnum],
+				weights0[threadnum], weights1[threadnum]);
+		}
 	}
 }
 

--- a/src/jaz/single_particle/motion/motion_estimator.h
+++ b/src/jaz/single_particle/motion/motion_estimator.h
@@ -23,6 +23,7 @@
 
 #include <src/image.h>
 #include <src/jaz/gravis/t2Vector.h>
+#include <src/jaz/image/contiguous_image_stack.h>
 #include <vector>
 
 class IOParser;
@@ -58,21 +59,29 @@ class MotionEstimator
 			const std::vector<Image<RFLOAT>>& dmgWeight,
 			int ogmg,
             // out:
-            std::vector<std::vector<Image<Complex>>>& movie,
-            std::vector<std::vector<Image<RFLOAT>>>& movieCC,
+            ContiguousImageStack<Complex>& movie,
+            ContiguousImageStack<RFLOAT>& movieCC,
             std::vector<gravis::d2Vector>& positions,
             std::vector<std::vector<gravis::d2Vector>>& initialTracks,
             std::vector<gravis::d2Vector>& globComp);
 
         // perform the actual optimization (also used by MotionParamEstimator)
         std::vector<std::vector<gravis::d2Vector>> optimize(
-            const std::vector<std::vector<Image<double>>>& movieCC,
+            const ContiguousImageStack<double>& movieCC,
             const std::vector<std::vector<gravis::d2Vector>>& inTracks,
             double sig_vel_px, double sig_acc_px, double sig_div_px,
             const std::vector<gravis::d2Vector>& positions,
             const std::vector<gravis::d2Vector>& globComp) const;
 
         // syntactic sugar for float-valued CCs
+        std::vector<std::vector<gravis::d2Vector>> optimize(
+            const ContiguousImageStack<float>& movieCC,
+            const std::vector<std::vector<gravis::d2Vector>>& inTracks,
+            double sig_vel_px, double sig_acc_px, double sig_div_px,
+            const std::vector<gravis::d2Vector>& positions,
+            const std::vector<gravis::d2Vector>& globComp) const;
+
+        // Compatibility path for the persistent parameter-estimation AlignmentSet.
         std::vector<std::vector<gravis::d2Vector>> optimize(
             const std::vector<std::vector<Image<float>>>& movieCC,
             const std::vector<std::vector<gravis::d2Vector>>& inTracks,
@@ -138,7 +147,7 @@ class MotionEstimator
 
 
         void updateFCC(
-            const std::vector<std::vector<Image<Complex>>>& movie,
+            ContiguousImageStack<Complex>& movie,
             const std::vector<std::vector<gravis::d2Vector>>& tracks,
             const MetaDataTable& mdt,
             std::vector<Image<RFLOAT>>& tables,

--- a/src/jaz/single_particle/motion/motion_helper.cpp
+++ b/src/jaz/single_particle/motion/motion_helper.cpp
@@ -33,25 +33,25 @@
 
 using namespace gravis;
 
-std::vector<std::vector<Image<RFLOAT>>> MotionHelper::movieCC(
-		const std::vector<std::vector<Image<Complex>>>& movie,
+void MotionHelper::movieCC(
+		const ContiguousImageStack<Complex>& movie,
 		const std::vector<Image<Complex>>& preds,
 		const std::vector<Image<RFLOAT> > &damageWeights,
-		double pad, int threads)
+		double pad, int threads,
+		ContiguousImageStack<RFLOAT>& out)
 {
-	const int pc = movie.size();
-	const int fc = movie[0].size();
+	const int pc = movie.particleCount();
+	const int fc = movie.frameCount();
 
-	const int s = movie[0][0]().ydim;
+	const int s = movie.ydim();
 	const int sh = s/2 + 1;
-
-	std::vector<std::vector<Image<RFLOAT>>> out(pc);
 
 	std::vector<Image<dComplex>> ccsFs(threads);
 	std::vector<Image<double>> ccsRs(threads);
 	
 	const int s2 = (int)(pad * s);
 	const int sh2 = s2/2 + 1;
+	out.resize(pc, fc, s2, s2);
 
 	for (int t = 0; t < threads; t++)
 	{
@@ -68,8 +68,6 @@ std::vector<std::vector<Image<RFLOAT>>> MotionHelper::movieCC(
 
 	for (int p = 0; p < pc; p++)
 	{
-		out[p] = std::vector<Image<RFLOAT>>(fc, Image<RFLOAT>(s2,s2));
-
 #pragma omp parallel for num_threads(threads)
 		for (int f = 0; f < fc; f++)
 		{
@@ -78,7 +76,7 @@ std::vector<std::vector<Image<RFLOAT>>> MotionHelper::movieCC(
 			for (int y = 0; y < s; y++)
 				for (int x = 0; x < sh; x++)
 				{
-					Complex z = movie[p][f](y,x) * damageWeights[f](y,x) * preds[p](y,x).conj();
+					Complex z = movie(p, f)(y,x) * damageWeights[f](y,x) * preds[p](y,x).conj();
 
 					const int yy = y < sh? y : s2 - (s - y);
 
@@ -90,12 +88,10 @@ std::vector<std::vector<Image<RFLOAT>>> MotionHelper::movieCC(
 			for (int y = 0; y < s2; y++)
 				for (int x = 0; x < s2; x++)
 				{
-					out[p][f](y,x) = s * s * ccsRs[t](y,x);
+					out(p, f)(y,x) = s * s * ccsRs[t](y,x);
 				}
 		}
 	}
-
-	return out;
 }
 
 /*std::vector<std::vector<Image<RFLOAT>>> MotionHelper::movieCC(
@@ -220,12 +216,12 @@ std::vector<std::vector<Image<RFLOAT>>> MotionHelper::movieCC(
 }*/
 
 std::vector<Image<RFLOAT> > MotionHelper::addCCs(
-		const std::vector<std::vector<Image<RFLOAT>>> &movieCC)
+		const ContiguousImageStack<RFLOAT>& movieCC)
 {
-	const int pc = movieCC.size();
-	const int fc = movieCC[0].size();
+	const int pc = movieCC.particleCount();
+	const int fc = movieCC.frameCount();
 
-	const int s = movieCC[0][0]().xdim;
+	const int s = movieCC.xdim();
 
 	std::vector<Image<RFLOAT>> e_sum(fc);
 
@@ -239,7 +235,7 @@ std::vector<Image<RFLOAT> > MotionHelper::addCCs(
 			for (int y = 0; y < s; y++)
 				for (int x = 0; x < s; x++)
 				{
-					e_sum[f](y,x) += movieCC[p][f](y,x);
+					e_sum[f](y,x) += movieCC(p, f)(y,x);
 				}
 		}
 	}
@@ -271,14 +267,16 @@ std::vector<d2Vector> MotionHelper::getGlobalTrack(
 	return out;
 }
 
+
+
 std::vector<d2Vector> MotionHelper::getGlobalOffsets(
-		const std::vector<std::vector<Image<RFLOAT>>>& movieCC,
+		const ContiguousImageStack<RFLOAT>& movieCC,
 		const std::vector<std::vector<gravis::d2Vector>>& initialTracks,
 		double cc_pad, double sigma, int wMax, int hMax, int threads)
 {
-	const int pc = movieCC.size();
-	const int fc = movieCC[0].size();
-	const int s = movieCC[0][0]().xdim;
+	const int pc = movieCC.particleCount();
+	const int fc = movieCC.frameCount();
+	const int s = movieCC.xdim();
 	const int sh = s/2 + 1;
 	const double eps = 1e-30;
 
@@ -307,7 +305,7 @@ std::vector<d2Vector> MotionHelper::getGlobalOffsets(
 			for (int y = 0; y < s; y++)
 				for (int x = 0; x < s; x++)
 				{
-					pSum(y,x) += Interpolation::cubicXY(movieCC[p][f], x + g.x, y + g.y, 0, 0, true);
+					pSum(y,x) += Interpolation::cubicXY(movieCC(p, f), x + g.x, y + g.y, 0, 0, true);
 				}
 		}
 
@@ -461,5 +459,3 @@ std::vector<std::vector<d2Vector>> MotionHelper::readTracksInPix(std::string fn,
 
 	return out;
 }
-
-

--- a/src/jaz/single_particle/motion/motion_helper.h
+++ b/src/jaz/single_particle/motion/motion_helper.h
@@ -32,6 +32,7 @@
 #include <src/jaz/gravis/t3Vector.h>
 #include <src/jaz/single_particle/obs_model.h>
 #include <src/jaz/single_particle/parallel_ft.h>
+#include <src/jaz/image/contiguous_image_stack.h>
 #include <vector>
 
 
@@ -39,11 +40,12 @@ class MotionHelper
 {
     public:
 
-        static std::vector<std::vector<Image<RFLOAT>>> movieCC(
-                const std::vector<std::vector<Image<Complex>>>& movie,
+        static void movieCC(
+                const ContiguousImageStack<Complex>& movie,
                 const std::vector<Image<Complex>>& preds,
                 const std::vector<Image<RFLOAT>>& damageWeights,
-                double pad, int threads);
+                double pad, int threads,
+                ContiguousImageStack<RFLOAT>& out);
 
         // deprecated: use the one above!
         /*static std::vector<std::vector<Image<RFLOAT>>> movieCC(
@@ -60,13 +62,13 @@ class MotionHelper
                 const std::vector<std::vector<Image<RFLOAT>>>& movieCC, double cc_pad);*/
 
         static std::vector<Image<RFLOAT>> addCCs(
-                const std::vector<std::vector<Image<RFLOAT>>>& movieCC);
+                const ContiguousImageStack<RFLOAT>& movieCC);
 
         static std::vector<gravis::d2Vector> getGlobalTrack(
                 const std::vector<Image<RFLOAT>>& movieCcSum, double cc_pad);
 
         static std::vector<gravis::d2Vector> getGlobalOffsets(
-                const std::vector<std::vector<Image<RFLOAT>>>& movieCC,
+                const ContiguousImageStack<RFLOAT>& movieCC,
                 const std::vector<std::vector<gravis::d2Vector>>& initialTracks, 
 				double cc_pad, double sigma, int wMax, int hMax, int threads);
 

--- a/src/jaz/single_particle/motion/motion_param_estimator.cpp
+++ b/src/jaz/single_particle/motion/motion_param_estimator.cpp
@@ -522,8 +522,8 @@ void MotionParamEstimator::prepAlignment()
         std::cout << "        micrograph " << (g+1) << " / " << gc << ": "
             << pc << " particles [" << pctot << " total]" << std::endl;
 
-        std::vector<std::vector<Image<Complex>>> movie;
-        std::vector<std::vector<Image<RFLOAT>>> movieCC;
+        ContiguousImageStack<Complex> movie;
+        ContiguousImageStack<RFLOAT> movieCC;
 
         try
         {
@@ -548,17 +548,21 @@ void MotionParamEstimator::prepAlignment()
         {
 			for (int f = 0; f < fc; f++)
             {
-				if (maxRange > 0)
+                if (maxRange > 0)
                 {
-                    movieCC[p][f] = FilterHelper::cropCorner2D(movieCC[p][f], maxRangeP, maxRangeP);
+                    Image<RFLOAT> cropped = FilterHelper::cropCorner2D(
+                        movieCC(p, f), maxRangeP, maxRangeP);
+                    alignmentSet.copyCC(g, p, f, cropped);
                 }
-
-                alignmentSet.copyCC(g, p, f, movieCC[p][f]);
+                else
+                {
+                    alignmentSet.copyCC(g, p, f, movieCC(p, f));
+                }
 
                 Image<Complex> pred = reference->predict(
                     mdts[g], p, *obsModel, ReferenceMap::Opposite);
 
-                alignmentSet.accelerate(movie[p][f], alignmentSet.obs[g][p][f]);
+                alignmentSet.accelerate(movie(p, f), alignmentSet.obs[g][p][f]);
                 alignmentSet.accelerate(pred, alignmentSet.pred[g][p]);
             }
         }
@@ -572,4 +576,3 @@ void MotionParamEstimator::prepAlignment()
 
     std::cout << "   done\n";
 }
-

--- a/src/jaz/single_particle/movie_loader.h
+++ b/src/jaz/single_particle/movie_loader.h
@@ -20,6 +20,17 @@ class MovieLoader
 				RFLOAT hot,
 				int num_threads);
 
+		template <typename T, typename FrameConsumer>
+		static void readDenseFrames(
+				std::string movieFn,
+				const RawImage<RFLOAT>* gainRef,
+				const RawImage<bool>* defectivePixels,
+				int frame0,
+				int numFrames,
+				RFLOAT hot,
+				int num_threads,
+				FrameConsumer&& consumeFrame);
+
 		template <typename T>
 		static BufferedImage<T> readEER(
 				std::string movieFn,
@@ -30,6 +41,18 @@ class MovieLoader
 				int eer_upsampling,
 				int eer_grouping,
 				int num_threads);
+
+		template <typename T, typename FrameConsumer>
+		static void readEERFrames(
+				std::string movieFn,
+				const RawImage<RFLOAT>* gainRef,
+				const RawImage<bool>* defectivePixels,
+				int frame0,
+				int numFrames,
+				int eer_upsampling,
+				int eer_grouping,
+				int num_threads,
+				FrameConsumer&& consumeFrame);
 
 		template <typename T>
 		static void fixDefects(
@@ -47,6 +70,34 @@ BufferedImage<T> MovieLoader::readDense(
 			int numFrames,
 			RFLOAT hot,
 			int num_threads)
+{
+	BufferedImage<T> out;
+
+	readDenseFrames<T>(
+		movieFn, gainRef, defectivePixels, frame0, numFrames, hot, num_threads,
+		[&out, numFrames](const RawImage<T>& frame, long int f)
+		{
+			if (f == 0)
+			{
+				out.resize(frame.xdim, frame.ydim, numFrames);
+			}
+
+			out.getSliceRef(f).copyFrom(frame);
+		});
+
+	return out;
+}
+
+template <typename T, typename FrameConsumer>
+void MovieLoader::readDenseFrames(
+			std::string movieFn,
+			const RawImage<RFLOAT>* gainRef,
+			const RawImage<bool>* defectivePixels,
+			int frame0,
+			int numFrames,
+			RFLOAT hot,
+			int num_threads,
+			FrameConsumer&& consumeFrame)
 {
 	const bool isCompressedMRC = CompressedMRCReader::isCompressedMRC(movieFn);
 
@@ -96,8 +147,6 @@ BufferedImage<T> MovieLoader::readDense(
 	}
 
 
-	BufferedImage<T> out(w0, h0, fc);
-
 	for (long f = 0; f < fc; f++)
 	{
 		Image<float> muGraphFrame_xmipp;
@@ -125,10 +174,8 @@ BufferedImage<T> MovieLoader::readDense(
 			fixDefects(muGraphFrame, defectivePixels, num_threads, false);
 		}
 
-		out.getSliceRef(f).copyFrom(muGraphFrame);
+		consumeFrame(muGraphFrame, f);
 	}
-
-	return out;
 }
 
 template <typename T>
@@ -201,6 +248,72 @@ BufferedImage<T> MovieLoader::readEER(
 	}
 
 	return out;
+}
+
+template <typename T, typename FrameConsumer>
+void MovieLoader::readEERFrames(
+		std::string movieFn,
+		const RawImage<RFLOAT>* gainRef,
+		const RawImage<bool>* defectivePixels,
+		int frame0,
+		int numFrames,
+		int eer_upsampling,
+		int eer_grouping,
+		int num_threads,
+		FrameConsumer&& consumeFrame)
+{
+	EERRenderer renderer;
+	renderer.read(movieFn, eer_upsampling);
+
+	const long int w0 = renderer.getWidth();
+	const long int h0 = renderer.getHeight();
+	const long int pixCt = w0 * h0;
+	const int fc = numFrames;
+	const std::string tag = "MovieLoader::readEERFrames: ";
+
+	const bool useGain = gainRef != 0;
+	if (useGain && (w0 != gainRef->xdim || h0 != gainRef->ydim))
+	{
+		REPORT_ERROR_STR(tag << "incompatible gain reference - size (x = " << gainRef->xdim
+				<< ", y = " << gainRef->ydim << ") is different from " << movieFn
+				<< " (x = " << w0 << ", y = " << h0 << ")");
+	}
+
+	const bool do_fixDefect = defectivePixels != 0;
+	if (do_fixDefect && (w0 != defectivePixels->xdim || h0 != defectivePixels->ydim))
+	{
+		REPORT_ERROR_STR(tag << "incompatible defect mask - size (x = " << defectivePixels->xdim
+				<< ", y = " << defectivePixels->ydim << ") is different from " << movieFn
+				<< " (x = " << w0 << ", y = " << h0 << ")");
+	}
+
+	for (int f = 0; f < fc; f++)
+	{
+		MultidimArray<float> muGraphFrame_xmipp;
+		// this takes 1-indexed frame numbers
+		renderer.renderFrames(
+				(frame0 + f) * eer_grouping + 1,
+				(frame0 + f + 1) * eer_grouping,
+				muGraphFrame_xmipp);
+
+		RawImage<T> muGraphFrame(muGraphFrame_xmipp);
+
+		#pragma omp parallel for num_threads(num_threads)
+		for (long int i = 0; i < pixCt; i++)
+		{
+			const RFLOAT val = muGraphFrame[i];
+			const RFLOAT gain = useGain? (*gainRef)[i] : 1.0;
+
+			muGraphFrame[i] = -gain * val;
+		}
+
+		if (do_fixDefect)
+		{
+			fixDefects(muGraphFrame, defectivePixels, num_threads, true);
+		}
+
+		consumeFrame(muGraphFrame, f);
+	}
 }
 
 template <typename T>

--- a/src/jaz/single_particle/spa_extraction.h
+++ b/src/jaz/single_particle/spa_extraction.h
@@ -4,9 +4,11 @@
 #include <src/metadata_table.h>
 #include <src/image.h>
 #include <src/jaz/image/raw_image.h>
+#include <src/jaz/image/contiguous_image_stack.h>
 #include <src/jaz/gravis/t2Vector.h>
 #include <src/jaz/single_particle/parallel_ft.h>
 #include <src/jaz/single_particle/img_proc/filter_helper.h>
+#include <omp.h>
 #include <vector>
 
 
@@ -24,7 +26,132 @@ class SpaExtraction
 				const std::vector<std::vector<gravis::d2Vector>>* offsets_in,
 				std::vector<std::vector<gravis::d2Vector>>* offsets_out,
 				int num_threads);
+
+		template <typename T>
+		static void extractMovieFrameFS(
+				const MetaDataTable& mdt,
+				const RawImage<T>& frame,
+				int frameIndex,
+				int frameCount,
+				int boxSize,
+				double outPs, double coordsPs, double moviePs, double dataPs,
+				const std::vector<std::vector<gravis::d2Vector>>* offsets_in,
+				std::vector<std::vector<gravis::d2Vector>>* offsets_out,
+				ContiguousImageStack<Complex>& out,
+				std::vector<ParFourierTransformer>& fts,
+				std::vector<Image<RFLOAT>>& aux0,
+				std::vector<Image<Complex>>& aux1);
 };
+
+template <typename T>
+void SpaExtraction::extractMovieFrameFS(
+		const MetaDataTable& mdt,
+		const RawImage<T>& frame,
+		int frameIndex,
+		int frameCount,
+		int boxSize,
+		double outPs, double coordsPs, double moviePs, double dataPs,
+		const std::vector<std::vector<gravis::d2Vector>>* offsets_in,
+		std::vector<std::vector<gravis::d2Vector>>* offsets_out,
+		ContiguousImageStack<Complex>& out,
+		std::vector<ParFourierTransformer>& fts,
+		std::vector<Image<RFLOAT>>& aux0,
+		std::vector<Image<Complex>>& aux1)
+{
+	const long int pc = mdt.numberOfObjects();
+	const int num_threads = fts.size();
+	const int sqMg = 2 * (int)(0.5 * boxSize * outPs / moviePs + 0.5);
+
+	if (dataPs < 0)
+	{
+		dataPs = outPs;
+	}
+
+	if (frameIndex == 0)
+	{
+		const int outputWidth = outPs == moviePs? sqMg / 2 + 1 : boxSize / 2 + 1;
+		const int outputHeight = outPs == moviePs? sqMg : boxSize;
+		out.resize(pc, frameCount, outputWidth, outputHeight);
+
+		aux0.resize(num_threads);
+		aux1.resize(num_threads);
+
+		for (int th = 0; th < num_threads; th++)
+		{
+			aux0[th] = Image<RFLOAT>(sqMg, sqMg);
+
+			if (outPs != moviePs)
+			{
+				aux1[th] = Image<Complex>(sqMg / 2 + 1, sqMg);
+			}
+		}
+	}
+
+	const int w0 = frame.xdim;
+	const int h0 = frame.ydim;
+
+	#pragma omp parallel for num_threads(num_threads)
+	for (long int p = 0; p < pc; p++)
+	{
+		const int t = omp_get_thread_num();
+		Image<Complex>& outputFrame = out(p, frameIndex);
+
+		double xpC, ypC;
+
+		mdt.getValue(EMDL_IMAGE_COORD_X, xpC, p);
+		mdt.getValue(EMDL_IMAGE_COORD_Y, ypC, p);
+
+		const double xpO = (int)(coordsPs * xpC / dataPs);
+		const double ypO = (int)(coordsPs * ypC / dataPs);
+
+		int x0 = (int)round(xpO * dataPs / moviePs) - sqMg / 2;
+		int y0 = (int)round(ypO * dataPs / moviePs) - sqMg / 2;
+
+		if (offsets_in != 0 && offsets_out != 0)
+		{
+			double dxM = (*offsets_in)[p][frameIndex].x * outPs / moviePs;
+			double dyM = (*offsets_in)[p][frameIndex].y * outPs / moviePs;
+
+			int dxI = (int)round(dxM);
+			int dyI = (int)round(dyM);
+
+			x0 += dxI;
+			y0 += dyI;
+
+			double dxR = (dxM - dxI) * moviePs / outPs;
+			double dyR = (dyM - dyI) * moviePs / outPs;
+
+			(*offsets_out)[p][frameIndex] = gravis::d2Vector(dxR, dyR);
+		}
+
+		for (long int y = 0; y < sqMg; y++)
+		for (long int x = 0; x < sqMg; x++)
+		{
+			int xx = x0 + x;
+			int yy = y0 + y;
+
+			if (xx < 0) xx = 0;
+			else if (xx >= w0) xx = w0 - 1;
+
+			if (yy < 0) yy = 0;
+			else if (yy >= h0) yy = h0 - 1;
+
+			DIRECT_NZYX_ELEM(aux0[t].data, 0, 0, y, x) = frame(xx, yy);
+		}
+
+		if (outPs == moviePs)
+		{
+			fts[t].FourierTransform(aux0[t](), outputFrame());
+		}
+		else
+		{
+			fts[t].FourierTransform(aux0[t](), aux1[t]());
+			FilterHelper::cropCorner2D(aux1[t], outputFrame);
+		}
+
+		outputFrame(0, 0) = Complex(0.0, 0.0);
+	}
+}
 
 template <typename T>
 std::vector<std::vector<Image<Complex>>> SpaExtraction::extractMovieStackFS(

--- a/src/jaz/single_particle/stack_helper.cpp
+++ b/src/jaz/single_particle/stack_helper.cpp
@@ -503,6 +503,46 @@ std::vector<double> StackHelper::powerSpectrum(const std::vector<std::vector<Ima
 	return out;
 }
 
+std::vector<double> StackHelper::powerSpectrum(const ContiguousImageStack<Complex>& stack)
+{
+	const int ic = stack.particleCount();
+	const int fc = stack.frameCount();
+	const int w = stack.xdim();
+	const int h = stack.ydim();
+
+	std::vector<double> out(w, 0.0), wgh(w, 0.0);
+
+	for (int i = 0; i < ic; i++)
+	for (int f = 0; f < fc; f++)
+	{
+		for (int y = 0; y < h; y++)
+		for (int x = 0; x < w; x++)
+		{
+			const Complex z = stack(i, f)(y, x);
+
+			const double yy = y < w? y : y - h;
+			const double xx = x;
+
+			const int r = (int) sqrt(xx * xx + yy * yy);
+
+			if (r >= w) continue;
+
+			out[r] += z.norm();
+			wgh[r] += 1.0;
+		}
+	}
+
+	for (int x = 0; x < w; x++)
+	{
+		if (wgh[x] > 0.0)
+		{
+			out[x] /= wgh[x];
+		}
+	}
+
+	return out;
+}
+
 std::vector<double> StackHelper::varSpectrum(const std::vector<std::vector<Image<Complex>>> &stack)
 {
 	const int ic = stack.size();

--- a/src/jaz/single_particle/stack_helper.h
+++ b/src/jaz/single_particle/stack_helper.h
@@ -28,6 +28,7 @@
 #include <src/jaz/single_particle/volume.h>
 #include <src/jaz/gravis/t2Matrix.h>
 #include <src/jaz/single_particle/parallel_ft.h>
+#include <src/jaz/image/contiguous_image_stack.h>
 #include <vector>
 
 class Projector;
@@ -78,6 +79,9 @@ class StackHelper
 		
 		static std::vector<double> powerSpectrum(
 					const std::vector<std::vector<Image<Complex>>>& stack);
+
+		static std::vector<double> powerSpectrum(
+					const ContiguousImageStack<Complex>& stack);
 		
 		static std::vector<double> varSpectrum(
 					const std::vector<std::vector<Image<Complex>>>& stack);


### PR DESCRIPTION
This PR reduces the peak memory and runtime of Bayesian polishing by removing the full corrected detector-movie stack from the motion-refinement path and consolidating particle/frame images into reusable contiguous allocations.

Instead of load everything into RAM at once and index them with offset like
```
std::vector<std::vector<Image<Complex>>> fullFrame=micrographHandler->loadMovie(...);
fullFrame[i][j];
```
It now uses an wrapper and index them with wrapper param. The wrapper will load frames only when needed.

```
ContiguousImageStack<Complex> fullFrame=micrographHandler->loadMovie(...);
fullFrame(i,j);
```


## Benchmark

The benchmark selects one raw micrograph containing 12 particles, which are from K3 superresolutioned dataset EMPIAR-12870. The raw size is 11,520 x 8,184 x 48 (head and tail are dropped).


| Run | Threads | Wall time | Peak RSS | Swap |
|---|---:|---:|---:|---:|
| RELION 5.1.1 | 1 | 87.35 s | 37.48 GiB | 0 |
| This PR | 1 | 55.93 s | 4.48 GiB | 0 |
| This PR | 32 | 44.60 s | 4.64 GiB | 0 |


## Numerical validation

The multithreaded polishing path **is not bit identical** for two reasons:

- motion fitting contains order-dependent floating-point reductions;
- detector-defect correction calls the process-global `rand()` from an OpenMP loop, so scheduling can assign different replacement samples to hot pixels.

With one thread over all 48 production frames:

- all trajectory scalars are exactly equal;
- the trajectory STAR files are bit identical;
- the complete voxel payloads of the FCC `cc`, `w0`, and `w1` MRC files are bit identical;

| Run | Maximum trajectory delta | RMS delta | Correlation |
|---|---:|---:|---:|
| Legacy 1 thread vs this PR 1 thread | 0 A | 0 A | 1 |
| This PR 1 thread vs this PR 32 threads | 0.006133 A | 0.001591967 A | 0.999999822621 |

The exact single-thread result establishes that the memory-layout and streaming changes preserve the polishing calculation when execution order is fixed. 

