### PR TITLE
amyloid finder: optimize amyloid line scoring

### DIFF
--- a/src/amyloid_finder.cpp
+++ b/src/amyloid_finder.cpp
@@ -18,6 +18,9 @@
  * author citations must be preserved.
  ***************************************************************************/
 #include "src/amyloid_finder.h"
+
+#include <algorithm>
+#include <cmath>
 //#define DEBUG_BOUNDS
 
 void AmyloidFinder::read(int argc, char **argv, int rank)
@@ -305,6 +308,219 @@ MultidimArray<RFLOAT> AmyloidFinder::growNonSignalMask(MultidimArray<RFLOAT> &in
     return Mresult;
 
 }
+
+namespace
+{
+struct AmyloidFrequencyBin
+{
+    int k;
+    bool is_signal;
+};
+
+struct AmyloidFrequencyTables
+{
+    int n;
+    std::vector<AmyloidFrequencyBin> bins;
+    std::vector<std::vector<RFLOAT> > cos_lut, sin_lut;
+    std::vector<RFLOAT> phase_cos, phase_sin;
+};
+
+AmyloidFrequencyTables buildAmyloidFrequencyTables(const AmyloidFinder &finder)
+{
+    AmyloidFrequencyTables tables;
+    tables.n = finder.ilengthmax;
+
+    for (int k = finder.imin_signal; k <= finder.imax_signal; k++)
+        tables.bins.push_back({k, true});
+    for (int k = finder.imin_nonsignal; k <= finder.imax_nonsignal; k++)
+        tables.bins.push_back({k, false});
+
+    tables.cos_lut.resize(tables.bins.size());
+    tables.sin_lut.resize(tables.bins.size());
+    tables.phase_cos.resize(tables.bins.size());
+    tables.phase_sin.resize(tables.bins.size());
+    for (long int ibin = 0; ibin < (long int)tables.bins.size(); ibin++)
+    {
+        const RFLOAT phase = 2. * PI * tables.bins[ibin].k / tables.n;
+        tables.phase_cos[ibin] = cos(phase);
+        tables.phase_sin[ibin] = sin(phase);
+        tables.cos_lut[ibin].resize(tables.n);
+        tables.sin_lut[ibin].resize(tables.n);
+        for (int i = 0; i < tables.n; i++)
+        {
+            tables.cos_lut[ibin][i] = cos(-phase * i);
+            tables.sin_lut[ibin][i] = sin(-phase * i);
+        }
+    }
+
+    return tables;
+}
+
+std::vector<int> getAmyloidSamplingCenters(int size, int skip_side_width, int shift_step)
+{
+    std::vector<int> centers;
+    for (int pos = 0; pos < size / 2 - skip_side_width; pos += shift_step)
+    {
+        centers.push_back(pos);
+        if (pos != 0)
+            centers.push_back(-pos);
+    }
+    std::sort(centers.begin(), centers.end());
+    return centers;
+}
+
+struct AmyloidScoreGeometry
+{
+    std::vector<int> x_centers;
+    std::vector<std::vector<int> > output_rows;
+};
+
+struct AmyloidRowScratch
+{
+    std::vector<RFLOAT> signal, nonsignal, real, imag;
+};
+
+AmyloidScoreGeometry buildAmyloidScoreGeometry(const AmyloidFinder &finder)
+{
+    AmyloidScoreGeometry geometry;
+    const int skip_side_width = finder.iwidthmax / 2;
+    const int skip_side_length = finder.ilengthmax / 2;
+    const int first_scored = skip_side_length - finder.crop_box / 2;
+    const int last_scored = finder.crop_box - skip_side_length - 1 - finder.crop_box / 2;
+
+    std::vector<int> x_centers = getAmyloidSamplingCenters(
+            finder.crop_box, skip_side_width, finder.shift_step);
+    for (long int i = 0; i < (long int)x_centers.size(); i++)
+        if (x_centers[i] >= first_scored && x_centers[i] <= last_scored)
+            geometry.x_centers.push_back(x_centers[i]);
+
+    geometry.output_rows.resize(finder.crop_box);
+    std::vector<int> y_centers = getAmyloidSamplingCenters(
+            finder.crop_box, skip_side_width, finder.shift_step);
+    for (long int i = 0; i < (long int)y_centers.size(); i++)
+    {
+        const int out_y = y_centers[i] / finder.shift_step;
+        for (int iwidth = 0; iwidth < finder.iwidthmax; iwidth++)
+        {
+            const int row_y = y_centers[i] + iwidth - finder.iwidthmax / 2;
+            if (row_y >= first_scored && row_y <= last_scored)
+                geometry.output_rows[row_y + finder.crop_box / 2].push_back(out_y);
+        }
+    }
+
+    return geometry;
+}
+
+void scoreAmyloidRowSliding(
+        const MultidimArray<RFLOAT> &image,
+        int row_y,
+        const AmyloidFrequencyTables &tables,
+        const std::vector<int> &x_centers,
+        AmyloidRowScratch &scratch)
+{
+    scratch.signal.assign(x_centers.size(), 0.);
+    scratch.nonsignal.assign(x_centers.size(), 0.);
+    if (x_centers.empty())
+        return;
+
+    const int half_length = tables.n / 2;
+    const int first_xpos = half_length;
+    const int last_xpos = XSIZE(image) - half_length - 1;
+    const int first_x = first_xpos - XSIZE(image) / 2;
+    const RFLOAT power_scale = 1. / ((RFLOAT)tables.n * tables.n);
+    scratch.real.assign(tables.bins.size(), 0.);
+    scratch.imag.assign(tables.bins.size(), 0.);
+
+    for (long int ibin = 0; ibin < (long int)tables.bins.size(); ibin++)
+    {
+        for (int i = 0; i < tables.n; i++)
+        {
+            const RFLOAT value = A2D_ELEM(image, row_y, first_x + i - half_length);
+            scratch.real[ibin] += value * tables.cos_lut[ibin][i];
+            scratch.imag[ibin] += value * tables.sin_lut[ibin][i];
+        }
+    }
+
+    long int next_center = 0;
+    for (int xpos = first_xpos; xpos <= last_xpos; xpos++)
+    {
+        const int x = xpos - XSIZE(image) / 2;
+        if (x == x_centers[next_center])
+        {
+            for (long int ibin = 0; ibin < (long int)tables.bins.size(); ibin++)
+            {
+                const RFLOAT power = (scratch.real[ibin] * scratch.real[ibin] +
+                                      scratch.imag[ibin] * scratch.imag[ibin]) * power_scale;
+                if (tables.bins[ibin].is_signal)
+                    scratch.signal[next_center] += power;
+                else
+                    scratch.nonsignal[next_center] += power;
+            }
+            if (++next_center == (long int)x_centers.size())
+                break;
+        }
+
+        const RFLOAT old_pixel = A2D_ELEM(image, row_y, x - half_length);
+        const RFLOAT new_pixel = A2D_ELEM(image, row_y, x + half_length);
+        for (long int ibin = 0; ibin < (long int)tables.bins.size(); ibin++)
+        {
+            const RFLOAT shifted_real = scratch.real[ibin] - old_pixel + new_pixel;
+            const RFLOAT shifted_imag = scratch.imag[ibin];
+            scratch.real[ibin] = tables.phase_cos[ibin] * shifted_real - tables.phase_sin[ibin] * shifted_imag;
+            scratch.imag[ibin] = tables.phase_sin[ibin] * shifted_real + tables.phase_cos[ibin] * shifted_imag;
+        }
+    }
+}
+
+void calculateAmyloidScoresFused(
+        const AmyloidFinder &finder,
+        const MultidimArray<RFLOAT> &image,
+        const AmyloidFrequencyTables &tables,
+        const AmyloidScoreGeometry &geometry,
+        MultidimArray<RFLOAT> &signal,
+        MultidimArray<RFLOAT> &nonsignal)
+{
+#pragma omp parallel num_threads(finder.nr_threads)
+    {
+        MultidimArray<RFLOAT> local_signal, local_nonsignal;
+        local_signal.initZeros(signal);
+        local_signal.setXmippOrigin();
+        local_nonsignal.initZeros(nonsignal);
+        local_nonsignal.setXmippOrigin();
+        AmyloidRowScratch scratch;
+
+#pragma omp for schedule(dynamic)
+        for (long int irow = 0; irow < (long int)geometry.output_rows.size(); irow++)
+        {
+            if (geometry.output_rows[irow].empty())
+                continue;
+
+            const int row_y = irow - YSIZE(image) / 2;
+            scoreAmyloidRowSliding(image, row_y, tables, geometry.x_centers, scratch);
+            for (long int ix = 0; ix < (long int)geometry.x_centers.size(); ix++)
+            {
+                const int out_x = geometry.x_centers[ix] / finder.shift_step;
+                for (long int iy = 0; iy < (long int)geometry.output_rows[irow].size(); iy++)
+                {
+                    const int out_y = geometry.output_rows[irow][iy];
+                    A2D_ELEM(local_signal, out_y, out_x) += scratch.signal[ix];
+                    A2D_ELEM(local_nonsignal, out_y, out_x) += scratch.nonsignal[ix];
+                }
+            }
+        }
+
+#pragma omp critical
+        {
+            FOR_ALL_DIRECT_ELEMENTS_IN_MULTIDIMARRAY(signal)
+            {
+                DIRECT_MULTIDIM_ELEM(signal, n) += DIRECT_MULTIDIM_ELEM(local_signal, n);
+                DIRECT_MULTIDIM_ELEM(nonsignal, n) += DIRECT_MULTIDIM_ELEM(local_nonsignal, n);
+            }
+        }
+    }
+}
+}
+
 void AmyloidFinder::getScoreForOneMicrograph(MultidimArray<RFLOAT> &image, MultidimArray<RFLOAT> &Mscore,
                                              MultidimArray<RFLOAT> &Mangle, RFLOAT &skew, RFLOAT &kurt, bool myverb)
 {
@@ -330,8 +546,7 @@ void AmyloidFinder::getScoreForOneMicrograph(MultidimArray<RFLOAT> &image, Multi
     }
 
     // Rotate the large image, and store downscaled images by cropping their Fourier Transform
-    std::vector<MultidimArray<RFLOAT> > rotated_imgs(nr_psi), rotated_scores_perline(nr_psi), rotated_scores(nr_psi);
-    std::vector<MultidimArray<RFLOAT> > rotated_nonscores_perline(nr_psi), rotated_nonscores(nr_psi);
+    std::vector<MultidimArray<RFLOAT> > rotated_imgs(nr_psi), rotated_scores(nr_psi), rotated_nonscores(nr_psi);
     std::vector<FourierTransformer> transformer(nr_threads);
     // TODO: in principle, only need to rotate to 90 degrees, as I can use both the X and the Y direction for the 1D FFTs!
     if (myverb)
@@ -387,102 +602,25 @@ void AmyloidFinder::getScoreForOneMicrograph(MultidimArray<RFLOAT> &image, Multi
     // Just prepare the rotated_scores vector too
     for (int ipsi = 0; ipsi < nr_psi; ipsi++)
     {
-        rotated_scores_perline[ipsi].initZeros(crop_box, crop_box);
-        rotated_scores_perline[ipsi].setXmippOrigin();
-        rotated_nonscores_perline[ipsi].initZeros(crop_box, crop_box);
-        rotated_nonscores_perline[ipsi].setXmippOrigin();
         rotated_scores[ipsi].initZeros(crop_box/shift_step, crop_box/shift_step);
         rotated_scores[ipsi].setXmippOrigin();
         rotated_nonscores[ipsi].initZeros(crop_box/shift_step, crop_box/shift_step);
         rotated_nonscores[ipsi].setXmippOrigin();
     }
 
-    // Prepare all the transformers for the 1D lines
-    MultidimArray<RFLOAT> oneline_tmp(ilengthmax);
-    for (int i = 0; i < nr_threads; i++)
-        transformer[i].setReal(oneline_tmp);
-
-    // Now loop over all positions to calculate 1D FFTs
+    // Now loop over all positions to calculate and aggregate the selected DFT bins
     if (myverb)
     {
         std::cout << " - Searching over all coordinates ..." << std::endl;
         init_progress_bar(nr_psi);
     }
 
-    int my_skip_side_length = ilengthmax/2;
+    const AmyloidFrequencyTables frequency_tables = buildAmyloidFrequencyTables(*this);
+    const AmyloidScoreGeometry score_geometry = buildAmyloidScoreGeometry(*this);
     for (int ipsi = 0; ipsi < nr_psi; ipsi++)
     {
-#pragma omp parallel for num_threads(nr_threads)
-        for (int ypos = my_skip_side_length; ypos < YSIZE(rotated_imgs[ipsi]) - my_skip_side_length; ypos += 1)
-        {
-            int cen_ypos = ypos - YSIZE(rotated_imgs[ipsi])/2;
-            const int tid = omp_get_thread_num();
-            MultidimArray<RFLOAT> oneline(ilengthmax);
-            MultidimArray<Complex> FTline(ilengthmax/2 + 1);
-
-            for (int xpos = my_skip_side_length; xpos < XSIZE(rotated_imgs[ipsi]) - my_skip_side_length; xpos += 1)
-            {
-                int cen_xpos = xpos - XSIZE(rotated_imgs[ipsi])/2;
-
-                // Grab the line from the rotated image, in X and in Y directions
-                for (int iline = 0; iline < ilengthmax; iline++)
-                    DIRECT_A1D_ELEM(oneline, iline) = A2D_ELEM(rotated_imgs[ipsi], cen_ypos, cen_xpos+iline-ilengthmax/2);
-
-                transformer[tid].FourierTransform(oneline, FTline, false);
-
-                for (int isig = imin_signal; isig <= imax_signal; isig++)
-                {
-                    A2D_ELEM(rotated_scores_perline[ipsi], cen_ypos, cen_xpos) += norm(DIRECT_A1D_ELEM(FTline, isig));
-                }
-                for (int isig = imin_nonsignal; isig <= imax_nonsignal; isig++)
-                {
-                    A2D_ELEM(rotated_nonscores_perline[ipsi], cen_ypos, cen_xpos) += norm(DIRECT_A1D_ELEM(FTline, isig));
-                }
-
-            } // end loop ypos
-        } // end for xpos
-
-        /*
-        Image<RFLOAT> It0;
-        It0()= rotated_scores_perline[ipsi];
-        FileName fnt0="It0_scores_psi"+ integerToString(ipsi)+".spi";
-        It0.write(fnt0);
-        std::cerr <<" written: "<<fnt0 << std::endl;
-        It0()= rotated_nonscores_perline[ipsi];
-        fnt0="It0_nonscores_psi"+ integerToString(ipsi)+".spi";
-        It0.write(fnt0);
-        std::cerr <<" written: "<<fnt0 << std::endl;
-        */
-
-        // Now that we have signal per individual line for each coordinate, sum over the width of the search box
-        // The below is split in two halves, becauses otherwise cen_pos=0 may be sampled twice!!!
-        int my_skip_side_width = iwidthmax/2;
- #pragma omp parallel for num_threads(nr_threads)
-        for (int ypos = 0; ypos < YSIZE(rotated_imgs[ipsi])/2 - my_skip_side_width; ypos += shift_step)
-        {
-           for (int ipassy = 0; ipassy < 2; ipassy++)
-           {
-               int cen_ypos = (ipassy == 0) ? ypos : -ypos;
-               if (ypos == 0 && ipassy == 1) continue;
-
-               for (int xpos = 0; xpos < XSIZE(rotated_imgs[ipsi])/2 - my_skip_side_width; xpos += shift_step)
-               {
-                   for (int ipass = 0; ipass < 2; ipass++)
-                   {
-                       int cen_xpos = (ipass == 0) ? xpos : -xpos;
-                       if (xpos == 0 && ipass == 1) continue;
-                       for (int iwidth = 0; iwidth < iwidthmax; iwidth++)
-                       {
-                           // Grab the line from the rotated image, in X and in Y directions
-                           A2D_ELEM(rotated_scores[ipsi], cen_ypos/shift_step, cen_xpos/shift_step) +=
-                                   A2D_ELEM(rotated_scores_perline[ipsi], cen_ypos+iwidth-iwidthmax/2, cen_xpos);
-                           A2D_ELEM(rotated_nonscores[ipsi], cen_ypos/shift_step, cen_xpos/shift_step) +=
-                                   A2D_ELEM(rotated_nonscores_perline[ipsi], cen_ypos+iwidth-iwidthmax/2, cen_xpos);
-                       } // end loop iwidth
-                   } // end loop ipass
-               } // end loop xpos
-           } // end for ipassy
-        } // end for ypos
+        calculateAmyloidScoresFused(*this, rotated_imgs[ipsi], frequency_tables, score_geometry,
+                                    rotated_scores[ipsi], rotated_nonscores[ipsi]);
 
         if (myverb) progress_bar(ipsi);
 


### PR DESCRIPTION
The final result of `relion_amyloid_finder` (before tracing) consists of two coarse 2D maps: PSI, containing the winning local orientation, and FOM, containing its relative angular-contrast
score.

For each sampled orientation and output location, it measures selected-bin 1D DFT power across a strip of parallel lines. The legacy implementation extracts every overlapping line window independently, computes a full FFT for each window, and stores the resulting signal and nonsignal powers in two dense full-resolution arrays, which are untouched until the last minute. A separate pass then aggregates those arrays across the filament width into coarse per-angle score maps.

This PR introduces two complementary optimizations:

1. Sliding narrowband DFT: For each image row, only the required signal and nonsignal frequency bins are computed for the first window. When the window moves by one pixel, those coefficients are updated by removing the departing pixel, adding the entering pixel, and applying a precomputed phase rotation. This avoids recomputing a complete FFT for every overlapping window.

2. Fused width aggregation: The implementation precomputes which coarse output cells receive each physical row’s score. As soon as the sampled signal and nonsignal powers for a row are calculated, they are accumulated into every affected coarse cell. No subsequent stage needs the individual row scores after this aggregation,  so their storage can be discarded or reused immediately, where most memory footprint is saved. Thus, the dense scores_perline and nonscores_perline images never need to be materialized; only the much smaller coarse per-angle score maps proceed to the PSI/FOM calculation.

This PR doesn't touch the math and should be equivalent. However aggregating powers early will change the order of float ops, which is not commute. Thus, it is expected that **the final result is not bit identical**. The PSI winning directions align, and maximum FOM absolute error is 1.49e-8 during the test.

The code, benchmark scripts and validation scripts are generated with GPT-5.6-sol. 
 
## Benchmark

The benchmark runs on a machine with 32C/64T AMD Zen 2 @ 3.1GHz CPU, 32 GiB 2666 MHz DDR4 x2 dual channel memory. Motion corrected, binned micrographs with final size 5,760 x 4,092 from EMPIAR-12870 dataset are used in benchmark.

For a single micrograph, 

| MPI/threads | Legacy time | Optimized time | Speedup | Legacy peak | Optimized peak | Memory reduction |
|---|---:|---:|---:|---:|---:|---:|
| 1/1 | 670.59 s | 379.09 s | 1.77x | 10.11 GiB | 4.13 GiB | 59.1% |
| 1/2 | 350.30 s | 201.36 s | 1.74x | 10.20 GiB | 4.36 GiB | 57.3% |
| 1/4 | 194.55 s | 115.09 s | 1.69x | 10.37 GiB | 6.17 GiB | 40.5% |
| 1/8 | 122.73 s | 77.57 s | 1.58x | 10.72 GiB | 10.13 GiB | 5.5% |
| 1/16 | 89.33 s | 62.24 s | 1.44x | 17.98 GiB | 18.04 GiB | -0.3% |

For n micrographs, where n can be divided by MPI procs, 

| Version | MPI ranks | Threads/rank | Total threads | Micrographs | Elapsed | Throughput | Peak memory |
|---|---:|---:|---:|---:|---:|---:|---:|
| Legacy | 1 | 32 | 32 | 2 | 75.75 s | 1.584 mic/min | 20.170 GiB |
| Legacy | 2 | 16 | 32 | 4 | 115.03 s | 2.086 mic/min | 35.797 GiB |
| Legacy | 3 | 10 | 30 | 6 | 150.85 s | 2.387 mic/min | 34.577 GiB |
| Legacy | 4 | 8 | 32 | 8 | 191.81 s | 2.502 mic/min | 41.119 GiB |
| **Legacy maximum** | **5** | **6** | **30** | **10** | **221.70 s** | **2.706 mic/min** | **51.149 GiB** |
| Optimized | 3 | 10 | 30 | 6 | 111.72 s | 3.222 mic/min | 34.645 GiB |
| Optimized | 4 | 8 | 32 | 8 | 141.28 s | 3.398 mic/min | 39.775 GiB |
| Optimized | 5 | 6 | 30 | 10 | 159.55 s | 3.761 mic/min | 39.167 GiB |
| Optimized | 8 | 4 | 32 | 16 | 274.48 s | 3.498 mic/min | 46.276 GiB |
| **Optimized maximum** | **9** | **3** | **27** | **18** | **273.05 s** | **3.955 mic/min** | **43.675 GiB** |
| Optimized | 10 | 3 | 30 | 20 | 305.97 s | 3.922 mic/min | 49.420 GiB |
| Optimized | 12 | 2 | 24 | 24 | 379.24 s | 3.797 mic/min | 48.262 GiB |
| Optimized | 13 | 2 | 26 | 26 | 411.01 s | 3.796 mic/min | 51.750 GiB |

